### PR TITLE
Running test in a single folder

### DIFF
--- a/src/main/java/com/ibr/fedora/App.java
+++ b/src/main/java/com/ibr/fedora/App.java
@@ -46,13 +46,7 @@ suite.setName("ldptest");
 final XmlTest test = new XmlTest(suite);
 
 final Map<String, String> params = new HashMap<String, String>();
-
 final List<XmlClass> classes = new ArrayList<XmlClass>();
-
-int i = 0;
-for (String arg : args) {
-params.put("param" + ++i, arg);
-}
 
 classes.add(new XmlClass("com.ibr.fedora.testsuite.HttpPost"));
 classes.add(new XmlClass("com.ibr.fedora.testsuite.HttpPut"));
@@ -61,6 +55,13 @@ classes.add(new XmlClass("com.ibr.fedora.testsuite.HttpHead"));
 classes.add(new XmlClass("com.ibr.fedora.testsuite.HttpDelete"));
 classes.add(new XmlClass("com.ibr.fedora.testsuite.ExternalBinaryContent"));
 classes.add(new XmlClass("com.ibr.fedora.testsuite.HttpPatch"));
+
+//Create the default container
+args[0] = TestSuiteGlobals.containerTestSuite(args[0]);
+int i = 0;
+for (String arg : args) {
+params.put("param" + ++i, arg);
+}
 
 test.setParameters(params);
 test.setXmlClasses(classes);

--- a/src/main/java/com/ibr/fedora/TestSuiteGlobals.java
+++ b/src/main/java/com/ibr/fedora/TestSuiteGlobals.java
@@ -34,6 +34,9 @@ import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.internal.Utils;
 
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+
 public abstract class TestSuiteGlobals {
 public static String cssReport = "reportStyle.css";
 public static String outputDirectory = "report";
@@ -43,6 +46,24 @@ public static String ldptNamespace = "http://fedora.info/2017/06/30/spec/#";
 public static String earlReportAssertor = "https://wiki.duraspace.org/display/FF";
 public static String resourcePointer;
 public static String[] payloadHeaders = {"Content-Length", "Content-Range", "Trailer", "Transfer-Encoding"};
+
+/**
+ * Get or create the default container for all tests resources to be created
+ * @param host
+ * @return containerUrl
+ */
+public static String containerTestSuite(final String host) {
+final String name = outputName + "container" + today();
+final String containerUrl = host + "/" + name.replaceAll("(?<!http:)//", "/");
+final Response res = RestAssured.given()
+.contentType("text/turtle")
+.header("slug", name).when().post(host);
+if (res.getStatusCode() == 201) {
+return containerUrl;
+} else {
+return host;
+}
+}
 
 /**
  * 
@@ -65,7 +86,7 @@ public static boolean checkPayloadHeader(final String header) {
  * @return date
  */
 public static String today() {
-    final String date = new SimpleDateFormat("MM-dd-yyyy HH-mm-ss").format(new Date());
+    final String date = new SimpleDateFormat("MMddyyyyHHmmss").format(new Date());
     return date;
 }
 /**

--- a/src/main/java/com/ibr/fedora/testsuite/HttpPost.java
+++ b/src/main/java/com/ibr/fedora/testsuite/HttpPost.java
@@ -20,19 +20,21 @@
  */
 package com.ibr.fedora.testsuite;
 
-import com.ibr.fedora.TestSuiteGlobals;
-import com.ibr.fedora.TestsLabels;
-import io.restassured.RestAssured;
-import io.restassured.config.LogConfig;
+import static org.hamcrest.Matchers.containsString;
+
+import java.io.FileNotFoundException;
+import java.io.PrintStream;
+
 import org.testng.SkipException;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
-import java.io.FileNotFoundException;
-import java.io.PrintStream;
+import com.ibr.fedora.TestSuiteGlobals;
+import com.ibr.fedora.TestsLabels;
 
-import static org.hamcrest.Matchers.containsString;
+import io.restassured.RestAssured;
+import io.restassured.config.LogConfig;
 
 @Listeners({com.ibr.fedora.report.HtmlReporter.class, com.ibr.fedora.report.EarlReporter.class})
 public class HttpPost {


### PR DESCRIPTION
All tests will now run on a single folder, to prevent generating too many RDFs or NonRDFs in the root folder.