### PR TITLE
Added Test 3.3-B - httpHeadResponseHeaderDigest

### DIFF
--- a/src/main/java/com/ibr/fedora/TestsLabels.java
+++ b/src/main/java/com/ibr/fedora/TestsLabels.java
@@ -213,7 +213,7 @@ public TestsLabels() { }
      public String[] respondWantDigest() {
      return new String[] {
      "3.2.3-A - HttpGet-RespondWantDigest",
-     "Testing for supported digest"
+     "Testing for supported digest "
      + "GET requests to any LDP-NR must correctly respond to the Want-Digest "
      + "header defined in [RFC3230]",
      "https://fcrepo.github.io/fcrepo-specification/#http-get-ldpnr",

--- a/src/main/java/com/ibr/fedora/TestsLabels.java
+++ b/src/main/java/com/ibr/fedora/TestsLabels.java
@@ -115,7 +115,7 @@ public TestsLabels() { }
     public String[] ldpPatchContentTypeSupport() {
     return new String[] {
     "3.7-B - HttpPatch-LDPPatchContentTypeSupport",
-    "Content-type for PATCH. Other content-types (e.g. [ldpatch]) may be available.",
+    "Other content-types (e.g. [ldpatch]) may be available.",
     "https://fcrepo.github.io/fcrepo-specification/#httpPATCH"
     };
     }
@@ -126,7 +126,7 @@ public TestsLabels() { }
     public String[] serverManagedPropertiesModification() {
     return new String[] {
     "3.7-C - HttpPatch-ServerManagedPropertiesModification",
-    "If an otherwise valid HTTP PATCH request is received that attempts to add "
+    "If an otherwise valid HTTP PATCH request is received that attempts to modify "
     + "statements to a resource that a server disallows (not ignores per [LDP] "
     + "4.2.4.1), the server must fail the request by responding with a 4xx range"
     + " status code (e.g. 409 Conflict).",
@@ -213,7 +213,8 @@ public TestsLabels() { }
      public String[] respondWantDigest() {
      return new String[] {
      "3.2.3-A - HttpGet-RespondWantDigest",
-     "GET requests to any LDP-NR must correctly respond to the Want-Digest "
+     "Testing for supported digest"
+     + "GET requests to any LDP-NR must correctly respond to the Want-Digest "
      + "header defined in [RFC3230]",
      "https://fcrepo.github.io/fcrepo-specification/#http-get-ldpnr",
      "MUST"
@@ -226,7 +227,7 @@ public TestsLabels() { }
     public String[] httpPost() {
     return new String[] {
     "3.5-A - HttpPost",
-    "Any LDPC must support POST ([LDP] 4.2.3 / 5.2.3).",
+    "Any LDPC (except Version Containers (LDPCv)) must support POST ([LDP] 4.2.3 / 5.2.3). ",
     "https://fcrepo.github.io/fcrepo-specification/#httpPOST",
     "MUST"
     };
@@ -302,9 +303,25 @@ public TestsLabels() { }
      * Basic information for described test
      * @return String[]
      */
+    public String[] httpPutSubtype() {
+    return new String[] {
+    "3.6-A - httpPutSubtype",
+    "When accepting a PUT request against an existant resource, an HTTP Link: rel=\"type\" header "
+    + "may be included. If the type in the Link header is a subtype of a current type of the resource, "
+    + "and has an interaction model assigned to it by [LDP],hen the resource must be assigned the new "
+    + "type and the interaction model of the resource must be changed to the interaction model assigned "
+    + "to the new type by [LDP].",
+    "https://fcrepo.github.io/fcrepo-specification/#httpPUT",
+    "MAY"
+    };
+    }
+    /**
+     * Basic information for described test
+     * @return String[]
+     */
     public String[] httpPut() {
     return new String[] {
-    "3.6-A - HttpPut",
+    "3.6-B - HttpPut",
     "When accepting a PUT request against an existant resource, an HTTP Link: rel=\"type\" header "
     + "may be included. If that type is a value in the LDP namespace and is not either a current "
     + "type of the resource or a subtype of a current type of the resource, the request must be "
@@ -385,7 +402,7 @@ public TestsLabels() { }
     public String[] putDigestResponseHeaderAuthentication() {
     return new String[] {
     "3.6.2-B - NonRDFSource-PutDigestResponseHeaderAuthentication",
-    "A HTTP PUT request that includes a Digest header (as described in [RFC3230]) for which any "
+    "An HTTP PUT request that includes a Digest header (as described in [RFC3230]) for which any "
     + "instance-digest in that header does not match the instance it describes, must be rejected "
     + "with a 409 Conflict response.",
     "https://fcrepo.github.io/fcrepo-specification/#httpPUTLDPNR",
@@ -399,8 +416,8 @@ public TestsLabels() { }
     public String[] putDigestResponseHeaderVerification() {
     return new String[] {
     "3.6.2-C - NonRDFSource-PutDigestResponseHeaderVerification",
-    "A HTTP PUT request that includes an unsupported Digest type (as described in [RFC3230]), should"
-    + " be rejected with a 400 Bad Request response.",
+    "An HTTP PUT request that includes an unsupported Digest type (as described in [RFC3230]), should"
+    + " be rejected with a 400 (Bad Request) response.",
     "https://fcrepo.github.io/fcrepo-specification/#httpPUTLDPNR",
     "SHOULD"
     };
@@ -411,9 +428,10 @@ public TestsLabels() { }
      */
     public String[] responseDescribesHeader() {
     return new String[] {
-    "3.2 - HttpGet-LDPRS-ResponseDescribesHeader",
-    "When the request is to the LDP-RS created to describe a LDP-NR, the response must include a Link: "
-    + "rel=\"describes\" header referencing the LDP-NR in question, as defined in [RFC6892].",
+    "3.2.2-B - HttpGet-LDPRS-ResponseDescribesHeader",
+    "When a GET request is made to an LDP-RS that describes an associated LDP-NR (3.5 HTTP POST and [LDP]5.2.3.12),"
+    + "the response must include a Link: rel=\"describes\" header referencing the LDP-NR "
+    + "in question, as defined in [RFC6892].",
     "http://fedora.info/2017/06/30/spec/#httpGET",
     "MUST"
     };
@@ -439,7 +457,7 @@ public TestsLabels() { }
      */
     public String[] responsePreferenceAppliedHeader() {
     return new String[] {
-    "3.2.2 - HttpGet-LDPRS-ResponsePreferenceAppliedHeader",
+    "3.2.2-A - HttpGet-LDPRS-ResponsePreferenceAppliedHeader",
     "Responses to GET requests that apply a Prefer request header to any LDP-RS must include the Preference-Applied"
     + " response header as defined in [RFC7240] section 3.",
     "http://fedora.info/2017/06/30/spec/#httpGETLDPRS",
@@ -454,7 +472,19 @@ public TestsLabels() { }
     return new String[] {
     "3.3-A - HttpHead-ResponseNoBody",
     "The HEAD method is identical to GET except that the server must not return a message-body in the response, as "
-    + "specified in [RFC7231] section 4.3.2. The server must send the same Digest header in the response as it"
+    + "specified in [RFC7231] section 4.3.2.",
+    "https://fcrepo.github.io/fcrepo-specification/#httpHEAD",
+    "MUST NOT"
+    };
+    }
+    /**
+     * Basic information for described test
+     * @return String[]
+     */
+    public String[] httpHeadResponseDigest() {
+    return new String[] {
+    "3.3-B - HttpHead-ResponseDigest",
+    "The server must send the same Digest header in the response as it"
     + " would have sent if the request had been a GET (or omit it if it would have been omitted for a GET).",
     "https://fcrepo.github.io/fcrepo-specification/#httpHEAD",
     "MUST NOT"
@@ -466,8 +496,9 @@ public TestsLabels() { }
      */
     public String[] httpHeadResponseHeadersSameAsHttpGet() {
     return new String[] {
-    "3.3-B - HttpHead-ResponseHeadersSameAsHttpGet",
-    "The server should send the same headers in response to a HEAD request as it would have sent if the request had "
+    "3.3-C - HttpHead-ResponseHeadersSameAsHttpGet",
+    "In other cases, The server should send the same headers in response to a HEAD request "
+    + "as it would have sent if the request had "
     + "been a GET, except that the payload headers (defined in [RFC7231] section 3.3) may be omitted.",
     "https://fcrepo.github.io/fcrepo-specification/#httpHEAD",
     "SHOULD"
@@ -617,7 +648,7 @@ public TestsLabels() { }
     "3.4-B - HttpOptions-HttpOptionsSupportAllow",
     "Any LDPR must support OPTIONS per [LDP] 4.2.8. "
     + "LDP servers must indicate their support for HTTP Methods by responding to a"
-    + "HTTP OPTIONS request on the LDPR’s URL with the HTTP Method tokens in the HTTP response header Allow.",
+    + " HTTP OPTIONS request on the LDPR’s URL with the HTTP Method tokens in the HTTP response header Allow.",
     "https://fcrepo.github.io/fcrepo-specification/#http-options",
     "MUST"
      };
@@ -629,7 +660,8 @@ public TestsLabels() { }
      public String[] respondWantDigestTwoSupported() {
      return new String[] {
      "3.2.3-B - HttpGet-RespondWantDigestTwoSupported",
-     "GET requests to any LDP-NR must correctly respond to the Want-Digest "
+     "Testing for two supported digests with no weights"
+     + " GET requests to any LDP-NR must correctly respond to the Want-Digest "
      + "header defined in [RFC3230]",
      "https://fcrepo.github.io/fcrepo-specification/#http-get-ldpnr",
      "MUST"
@@ -642,7 +674,8 @@ public TestsLabels() { }
      public String[] respondWantDigestTwoSupportedQvalueNonZero() {
       return new String[] {
       "3.2.3-C - HttpGet-RespondWantDigestTwoSupportedQvalueNonZero",
-      "GET requests to any LDP-NR must correctly respond to the Want-Digest "
+      "Testing for two supported digests with different weights"
+      + "GET requests to any LDP-NR must correctly respond to the Want-Digest "
       + "header defined in [RFC3230]",
       "https://fcrepo.github.io/fcrepo-specification/#http-get-ldpnr",
        "MUST"
@@ -655,8 +688,9 @@ public TestsLabels() { }
      public String[] respondWantDigestTwoSupportedQvalueZero() {
        return new String[] {
        "3.2.3-D - HttpGet-RespondWantDigestTwoSupportedQvalueZero",
-       "GET requests to any LDP-NR must correctly respond to the Want-Digest "
-       + "header defined in [RFC3230]",
+       "Testing for two supported digests with different weights q=0.3,q=0"
+       + " GET requests to any LDP-NR must correctly respond to the Want-Digest"
+       + " header defined in [RFC3230]",
        "https://fcrepo.github.io/fcrepo-specification/#http-get-ldpnr",
         "MUST"
        };
@@ -668,7 +702,8 @@ public TestsLabels() { }
      public String[] respondWantDigestNonSupported() {
        return new String[] {
        "3.2.3-E - HttpGet-RespondWantDigestNonSupported",
-       "GET requests to any LDP-NR must correctly respond to the Want-Digest "
+       "Testing for one supported digest and one unsupported digest."
+       + "GET requests to any LDP-NR must correctly respond to the Want-Digest "
        + "header defined in [RFC3230]",
        "https://fcrepo.github.io/fcrepo-specification/#http-get-ldpnr",
         "MUST"

--- a/src/main/java/com/ibr/fedora/testsuite/ExternalBinaryContent.java
+++ b/src/main/java/com/ibr/fedora/testsuite/ExternalBinaryContent.java
@@ -60,11 +60,11 @@ public class ExternalBinaryContent {
      * 3.8-A
      * @param host
      */
-    @Test(priority = 41)
+    @Test(priority = 42)
     @Parameters({"param1"})
     public void postCreateExternalBinaryContent(final String host) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
-        ps.append("\n41." + tl.postCreateExternalBinaryContent()[1]).append('\n');
+        ps.append("\n42." + tl.postCreateExternalBinaryContent()[1]).append('\n');
         ps.append("Request:\n");
 
         RestAssured.given()
@@ -85,11 +85,11 @@ public class ExternalBinaryContent {
      * 3.8-A
      * @param host
      */
-    @Test(priority = 42)
+    @Test(priority = 43)
     @Parameters({"param1"})
     public void putCreateExternalBinaryContent(final String host) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
-        ps.append("\n42." + tl.putCreateExternalBinaryContent()[1]).append('\n');
+        ps.append("\n43." + tl.putCreateExternalBinaryContent()[1]).append('\n');
         ps.append("Request:\n");
 
         RestAssured.given()
@@ -110,11 +110,11 @@ public class ExternalBinaryContent {
      * 3.8-A
      * @param host
      */
-    @Test(priority = 43)
+    @Test(priority = 44)
     @Parameters({"param1"})
     public void putUpdateExternalBinaryContent(final String host) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
-        ps.append("\n43." + tl.putUpdateExternalBinaryContent()[1]).append('\n');
+        ps.append("\n44." + tl.putUpdateExternalBinaryContent()[1]).append('\n');
         ps.append("Request:\n");
 
         final String resource =
@@ -141,11 +141,11 @@ public class ExternalBinaryContent {
      * 3.8-C
      * @param host
      */
-    @Test(priority = 44)
+    @Test(priority = 45)
     @Parameters({"param1"})
     public void postCheckUnsupportedMediaType(final String host) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
-        ps.append("\n44." + tl.postCheckUnsupportedMediaType()[1]).append('\n');
+        ps.append("\n45." + tl.postCheckUnsupportedMediaType()[1]).append('\n');
         ps.append("Request:\n");
 
         RestAssured.given()
@@ -167,11 +167,11 @@ public class ExternalBinaryContent {
      * 3.8-C
      * @param host
      */
-    @Test(priority = 45)
+    @Test(priority = 46)
     @Parameters({"param1"})
     public void putCheckUnsupportedMediaType(final String host) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
-        ps.append("\n45." + tl.putCheckUnsupportedMediaType()[1]).append('\n');
+        ps.append("\n46." + tl.putCheckUnsupportedMediaType()[1]).append('\n');
         ps.append("Request:\n");
 
         RestAssured.given()
@@ -192,11 +192,11 @@ public class ExternalBinaryContent {
      * 3.8-E
      * @param host
      */
-    @Test(priority = 46)
+    @Test(priority = 47)
     @Parameters({"param1"})
     public void getCheckContentLocationHeader(final String host) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
-        ps.append("\n46." + tl.getCheckContentLocationHeader()[1]).append('\n');
+        ps.append("\n47." + tl.getCheckContentLocationHeader()[1]).append('\n');
         ps.append("Request:\n");
 
         final String resource =
@@ -242,11 +242,11 @@ public class ExternalBinaryContent {
      * 3.8-E
      * @param host
      */
-    @Test(priority = 47)
+    @Test(priority = 48)
     @Parameters({"param1"})
     public void headCheckContentLocationHeader(final String host) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
-        ps.append("\n47." + tl.headCheckContentLocationHeader()[1]).append('\n');
+        ps.append("\n48." + tl.headCheckContentLocationHeader()[1]).append('\n');
         ps.append("Request:\n");
 
         final String resource =

--- a/src/main/java/com/ibr/fedora/testsuite/HttpDelete.java
+++ b/src/main/java/com/ibr/fedora/testsuite/HttpDelete.java
@@ -58,7 +58,7 @@ import io.restassured.response.Response;
      * 4.2.6
      * @param host
      */
-    @Test(priority = 40)
+    @Test(priority = 41)
     @Parameters({"param1"})
     public void httpDelete(final String host) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();

--- a/src/main/java/com/ibr/fedora/testsuite/HttpGet.java
+++ b/src/main/java/com/ibr/fedora/testsuite/HttpGet.java
@@ -52,39 +52,10 @@ public class HttpGet {
     }
 
     /**
-     * 3.2
-     * @param host
-     */
-    @Test(priority = 6)
-    @Parameters({"param1"})
-    public void responseDescribesHeader(final String host) throws FileNotFoundException {
-        final PrintStream ps = TestSuiteGlobals.logFile();
-        ps.append("\n6." + tl.responseDescribesHeader()[1] + "-" + tl.responseDescribesHeader()[1]).append("\n");
-        ps.append("Request:\n");
-        final String resource =
-            RestAssured.given()
-    .auth().basic(this.username, this.password)
-                .header("Content-Disposition", "attachment; filename=\"responseDescribesHeader.txt\"")
-                .when()
-                .post(host).asString();
-        RestAssured.given()
-    .auth().basic(this.username, this.password)
-            .config(RestAssured.config().logConfig(new LogConfig().defaultStream(ps)))
-            .log().all()
-            .when()
-            .get(resource + "/fcr:metadata")
-            .then()
-            .log().all()
-            .statusCode(200).header("Link", containsString("describes"));
-
-        ps.append("\n -Case End- \n").close();
-    }
-
-    /**
      * 3.2.1-A
      * @param host
      */
-    @Test(priority = 7)
+    @Test(priority = 6)
     @Parameters({"param1"})
     public void additionalValuesForPreferHeader(final String host) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -113,10 +84,10 @@ public class HttpGet {
     }
 
     /**
-     * 3.2.2
+     * 3.2.2-A
      * @param host
      */
-    @Test(priority = 8)
+    @Test(priority = 7)
     @Parameters({"param1"})
     public void responsePreferenceAppliedHeader(final String host) throws FileNotFoundException {
     final PrintStream ps = TestSuiteGlobals.logFile();
@@ -141,7 +112,34 @@ public class HttpGet {
 
     ps.append("\n -Case End- \n").close();
       }
+    /**
+     * 3.2.2-B
+     * @param host
+     */
+    @Test(priority = 8)
+    @Parameters({"param1"})
+    public void responseDescribesHeader(final String host) throws FileNotFoundException {
+        final PrintStream ps = TestSuiteGlobals.logFile();
+        ps.append("\n6." + tl.responseDescribesHeader()[1] + "-" + tl.responseDescribesHeader()[1]).append("\n");
+        ps.append("Request:\n");
+        final String resource =
+            RestAssured.given()
+    .auth().basic(this.username, this.password)
+                .header("Content-Disposition", "attachment; filename=\"responseDescribesHeader.txt\"")
+                .when()
+                .post(host).asString();
+        RestAssured.given()
+    .auth().basic(this.username, this.password)
+            .config(RestAssured.config().logConfig(new LogConfig().defaultStream(ps)))
+            .log().all()
+            .when()
+            .get(resource + "/fcr:metadata")
+            .then()
+            .log().all()
+            .statusCode(200).header("Link", containsString("describes"));
 
+        ps.append("\n -Case End- \n").close();
+    }
     /**
      * 3.2.3-A
      * @param host

--- a/src/main/java/com/ibr/fedora/testsuite/HttpHead.java
+++ b/src/main/java/com/ibr/fedora/testsuite/HttpHead.java
@@ -94,7 +94,6 @@ public class HttpHead {
     @Test(priority = 15)
     @Parameters({"param1"})
     public void httpHeadResponseDigest(final String host) throws FileNotFoundException {
-        //final String checksum = "md5";
         final PrintStream ps = TestSuiteGlobals.logFile();
         ps.append("\n15." + tl.httpHeadResponseDigest()[1]).append("\n");
         ps.append("Request:\n");
@@ -110,7 +109,6 @@ public class HttpHead {
          final Response resget =
          RestAssured.given()
                  .auth().basic(this.username, this.password)
-                 //.header("Want-Digest",checksum)
                  .config(RestAssured.config().logConfig(new LogConfig().defaultStream(ps)))
                  .log().all()
                  .when()
@@ -126,7 +124,6 @@ public class HttpHead {
         final Response reshead =
         RestAssured.given()
                 .auth().basic(this.username, this.password)
-                //.header("Want-Digest",checksum)
                 .config(RestAssured.config().logConfig(new LogConfig().defaultStream(ps)))
                 .log().all()
                 .when()

--- a/src/main/java/com/ibr/fedora/testsuite/HttpHead.java
+++ b/src/main/java/com/ibr/fedora/testsuite/HttpHead.java
@@ -27,8 +27,10 @@ import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.config.LogConfig;
 import io.restassured.http.Header;
 import io.restassured.http.Headers;
+import io.restassured.response.Response;
 import io.restassured.specification.ResponseSpecification;
 
+import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
@@ -53,8 +55,8 @@ public class HttpHead {
     @BeforeClass
     @Parameters({"param2", "param3"})
     public void auth(final String username, final String password) {
-    this.username = username;
-    this.password = password;
+        this.username = username;
+        this.password = password;
     }
 
     /**
@@ -85,16 +87,87 @@ public class HttpHead {
 
         ps.append("\n -Case End- \n").close();
     }
-
     /**
      * 3.3-B
      * @param host
      */
     @Test(priority = 15)
     @Parameters({"param1"})
+    public void httpHeadResponseDigest(final String host) throws FileNotFoundException {
+        //final String checksum = "md5";
+        final PrintStream ps = TestSuiteGlobals.logFile();
+        ps.append("\n15." + tl.httpHeadResponseDigest()[1]).append("\n");
+        ps.append("Request:\n");
+        final String resource =
+        RestAssured.given()
+                .auth().basic(this.username, this.password)
+                .header("Content-Disposition", "attachment; filename=\"headerwantdigest.txt\"")
+                .body("TestString.")
+                .when()
+                .post(host).asString();
+
+
+         final Response resget =
+         RestAssured.given()
+                 .auth().basic(this.username, this.password)
+                 //.header("Want-Digest",checksum)
+                 .config(RestAssured.config().logConfig(new LogConfig().defaultStream(ps)))
+                 .log().all()
+                 .when()
+                 .get(resource);
+
+                 ps.append(resget.getStatusLine().toString() + "\n");
+                 final Headers heade = resget.getHeaders();
+                 for (Header h : heade) {
+                      ps.append(h.getName().toString() + ": ");
+                      ps.append(h.getValue().toString() + "\n");
+                }
+
+        final Response reshead =
+        RestAssured.given()
+                .auth().basic(this.username, this.password)
+                //.header("Want-Digest",checksum)
+                .config(RestAssured.config().logConfig(new LogConfig().defaultStream(ps)))
+                .log().all()
+                .when()
+                .head(resource);
+                ps.append(reshead.getStatusLine().toString() + "\n");
+                final Headers headers = reshead.getHeaders();
+                for (Header h : headers) {
+                     ps.append(h.getName().toString() + ": ");
+                     ps.append(h.getValue().toString() + "\n");
+                }
+
+        ps.append("\n -Case End- \n").close();
+
+        if (resget.getStatusCode() == 200 && reshead.getStatusCode() == 200) {
+
+            if (resget.getHeader("Digest") == null) {
+                if (reshead.getHeader("Digest") == null) {
+                    Assert.assertTrue(true, "OK");
+                } else {
+                    Assert.assertTrue(false, "FAIL");
+                }
+            } else {
+                if (reshead.getHeader("Digest") == null) {
+                    Assert.assertTrue(false, "FAIL");
+                } else {
+                    Assert.assertTrue(true, "OK");
+                }
+            }
+        } else {
+           Assert.assertTrue(false, "FAIL");
+        }
+    }
+    /**
+     * 3.3-C
+     * @param host
+     */
+    @Test(priority = 16)
+    @Parameters({"param1"})
     public void httpHeadResponseHeadersSameAsHttpGet(final String host) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
-        ps.append("\n15." + tl.httpHeadResponseHeadersSameAsHttpGet()[1]).append("\n");
+        ps.append("\n16." + tl.httpHeadResponseHeadersSameAsHttpGet()[1]).append("\n");
         ps.append("Request:\n");
         final String resource =
                 RestAssured.given()

--- a/src/main/java/com/ibr/fedora/testsuite/HttpOptions.java
+++ b/src/main/java/com/ibr/fedora/testsuite/HttpOptions.java
@@ -56,11 +56,11 @@ public class HttpOptions {
      * 3.4-A
      * @param host
      */
-    @Test(priority = 16)
+    @Test(priority = 17)
     @Parameters({"param1"})
     public void httpOptionsSupport(final String host) throws FileNotFoundException {
          final PrintStream ps = TestSuiteGlobals.logFile();
-    ps.append("\n16." + tl.httpOptionsSupport()[1]).append("\n");
+    ps.append("\n17." + tl.httpOptionsSupport()[1]).append("\n");
     ps.append("Request:\n");
 
     RestAssured.given()
@@ -80,11 +80,11 @@ public class HttpOptions {
      * 3.4-B
      * @param host
      */
-    @Test(priority = 17)
+    @Test(priority = 18)
     @Parameters({"param1"})
     public void httpOptionsSupportAllow(final String host) throws FileNotFoundException {
     final PrintStream ps = TestSuiteGlobals.logFile();
-    ps.append("\n17." + tl.httpOptionsSupportAllow()[1]).append("\n");
+    ps.append("\n18." + tl.httpOptionsSupportAllow()[1]).append("\n");
     ps.append("Request:\n");
 
     RestAssured.given()

--- a/src/main/java/com/ibr/fedora/testsuite/HttpPatch.java
+++ b/src/main/java/com/ibr/fedora/testsuite/HttpPatch.java
@@ -86,11 +86,11 @@ public class HttpPatch {
      * 3.7-A
      * @param host
      */
-    @Test(priority = 32)
+    @Test(priority = 33)
     @Parameters({"param1"})
     public void supportPatch(final String host) throws IOException {
         final PrintStream ps = TestSuiteGlobals.logFile();
-        ps.append("\n32." + tl.supportPatch()[1]).append('\n');
+        ps.append("\n33." + tl.supportPatch()[1]).append('\n');
         ps.append("Request:\n");
 
         final String resource =
@@ -120,11 +120,11 @@ public class HttpPatch {
      * 3.7-B
      * @param host
      */
-    @Test(priority = 33)
+    @Test(priority = 34)
     @Parameters({"param1"})
     public void ldpPatchContentTypeSupport(final String host) throws IOException {
         final PrintStream ps = TestSuiteGlobals.logFile();
-        ps.append("\n33." + tl.ldpPatchContentTypeSupport()[1]).append('\n');
+        ps.append("\n34." + tl.ldpPatchContentTypeSupport()[1]).append('\n');
         ps.append("Request:\n");
 
         final String resource =
@@ -154,11 +154,11 @@ public class HttpPatch {
      * 3.7-C
      * @param host
      */
-    @Test(priority = 34)
+    @Test(priority = 35)
     @Parameters({"param1"})
     public void serverManagedPropertiesModification(final String host) throws IOException {
         final PrintStream ps = TestSuiteGlobals.logFile();
-        ps.append("\n34." + tl.serverManagedPropertiesModification()[1]).append('\n');
+        ps.append("\n35." + tl.serverManagedPropertiesModification()[1]).append('\n');
         ps.append("Request:\n");
 
         final String resource =
@@ -188,11 +188,11 @@ public class HttpPatch {
      * 3.7-D
      * @param host
      */
-    @Test(priority = 35)
+    @Test(priority = 36)
     @Parameters({"param1"})
     public void statementNotPersistedResponseBody(final String host) throws IOException {
         final PrintStream ps = TestSuiteGlobals.logFile();
-        ps.append("\n35." + tl.statementNotPersistedResponseBody()[1]).append('\n');
+        ps.append("\n36." + tl.statementNotPersistedResponseBody()[1]).append('\n');
         ps.append("Request:\n");
 
         final String resource =
@@ -222,11 +222,11 @@ public class HttpPatch {
      * 3.7-E
      * @param host
      */
-    @Test(priority = 36)
+    @Test(priority = 37)
     @Parameters({"param1"})
     public void statementNotPersistedConstrainedBy(final String host) throws IOException {
         final PrintStream ps = TestSuiteGlobals.logFile();
-        ps.append("\n36." + tl.statementNotPersistedConstrainedBy()[1]).append('\n');
+        ps.append("\n37." + tl.statementNotPersistedConstrainedBy()[1]).append('\n');
         ps.append("Request:\n");
 
         final String resource =
@@ -256,11 +256,11 @@ public class HttpPatch {
      * 3.7-F
      * @param host
      */
-    @Test(priority = 37)
+    @Test(priority = 38)
     @Parameters({"param1"})
     public void successfulPatchStatusCode(final String host) throws IOException {
         final PrintStream ps = TestSuiteGlobals.logFile();
-        ps.append("\n37." + tl.successfulPatchStatusCode()[1]).append('\n');
+        ps.append("\n38." + tl.successfulPatchStatusCode()[1]).append('\n');
         ps.append("Request:\n");
 
         final String resource =
@@ -315,11 +315,11 @@ public class HttpPatch {
      * 3.7.1
      * @param host
      */
-    @Test(priority = 38)
+    @Test(priority = 39)
     @Parameters({"param1"})
     public void disallowPatchContainmentTriples(final String host) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
-        ps.append("\n38." + tl.disallowPatchContainmentTriples()[1]).append('\n');
+        ps.append("\n39." + tl.disallowPatchContainmentTriples()[1]).append('\n');
         ps.append("Request:\n");
 
         final String container =
@@ -356,11 +356,11 @@ public class HttpPatch {
      * 3.7.2
      * @param host
      */
-    @Test(priority = 39)
+    @Test(priority = 40)
     @Parameters({"param1"})
     public void disallowChangeResourceType(final String host) throws IOException {
         final PrintStream ps = TestSuiteGlobals.logFile();
-        ps.append("\n39." + tl.disallowChangeResourceType()[1]).append('\n');
+        ps.append("\n40." + tl.disallowChangeResourceType()[1]).append('\n');
         ps.append("Request:\n");
 
         final String resource =

--- a/src/main/java/com/ibr/fedora/testsuite/HttpPost.java
+++ b/src/main/java/com/ibr/fedora/testsuite/HttpPost.java
@@ -58,11 +58,11 @@ public class HttpPost {
      * 3.5-A
      * @param host
      */
-    @Test(priority = 18)
+    @Test(priority = 19)
     @Parameters({"param1"})
     public void httpPost(final String host) throws FileNotFoundException {
     final PrintStream ps = TestSuiteGlobals.logFile();
-    ps.append("\n18." + tl.httpPost()[1]).append("\n");
+    ps.append("\n19." + tl.httpPost()[1]).append("\n");
     ps.append("Request:\n");
     RestAssured.given()
     .auth().basic(this.username, this.password)
@@ -81,11 +81,11 @@ public class HttpPost {
      * 3.5-B
      * @param host
      */
-    @Test(priority = 19)
+    @Test(priority = 20)
     @Parameters({"param1"})
     public void constrainedByResponseHeader(final String host) throws FileNotFoundException {
     final PrintStream ps = TestSuiteGlobals.logFile();
-    ps.append("\n19." + tl.constrainedByResponseHeader()[1]).append("\n");
+    ps.append("\n20." + tl.constrainedByResponseHeader()[1]).append("\n");
     ps.append("Request:\n");
 
     final String resource =
@@ -114,11 +114,11 @@ public class HttpPost {
      * 3.5-C
      * @param host
      */
-    @Test(priority = 20)
+    @Test(priority = 21)
     @Parameters({"param1"})
     public void postNonRDFSource(final String host) throws FileNotFoundException {
     final PrintStream ps = TestSuiteGlobals.logFile();
-    ps.append("\n20." + tl.postNonRDFSource()[1]).append('\n');
+    ps.append("\n21." + tl.postNonRDFSource()[1]).append('\n');
     ps.append("Request:\n");
     RestAssured.given()
     .auth().basic(this.username, this.password)
@@ -137,11 +137,11 @@ public class HttpPost {
      * 3.5-D
      * @param host
      */
-    @Test(priority = 21)
+    @Test(priority = 22)
     @Parameters({"param1"})
     public void postResourceAndCheckAssociatedResource(final String host) throws FileNotFoundException {
     final PrintStream ps = TestSuiteGlobals.logFile();
-    ps.append("\n21." + tl.postResourceAndCheckAssociatedResource()[1]).append('\n');
+    ps.append("\n22." + tl.postResourceAndCheckAssociatedResource()[1]).append('\n');
     ps.append("Request:\n");
     RestAssured.given()
     .auth().basic(this.username, this.password)
@@ -161,12 +161,12 @@ public class HttpPost {
      * 3.5.1-A
      * @param host
      */
-    @Test(priority = 22)
+    @Test(priority = 23)
     @Parameters({"param1"})
     public void postDigestResponseHeaderAuthentication(final String host) throws FileNotFoundException {
         final String checksum = "sha1=372ea08cab33e71c02c651dbc83a474d32c676b";
         final PrintStream ps = TestSuiteGlobals.logFile();
-        ps.append("\n22." + tl.postDigestResponseHeaderAuthentication()[1]).append('\n');
+        ps.append("\n23." + tl.postDigestResponseHeaderAuthentication()[1]).append('\n');
         ps.append("Request:\n");
         RestAssured.given()
     .auth().basic(this.username, this.password)
@@ -188,12 +188,12 @@ public class HttpPost {
      * 3.5.1-B
      * @param host
      */
-    @Test(priority = 23)
+    @Test(priority = 24)
     @Parameters({"param1"})
     public void postDigestResponseHeaderVerification(final String host) throws FileNotFoundException {
         final String checksum = "abc=abc";
         final PrintStream ps = TestSuiteGlobals.logFile();
-        ps.append("\n23." + tl.postDigestResponseHeaderVerification()[1]).append('\n');
+        ps.append("\n24." + tl.postDigestResponseHeaderVerification()[1]).append('\n');
         ps.append("Request:\n");
 
         RestAssured.given()

--- a/src/main/java/com/ibr/fedora/testsuite/HttpPut.java
+++ b/src/main/java/com/ibr/fedora/testsuite/HttpPut.java
@@ -55,12 +55,12 @@ public class HttpPut {
      * 3.6-A
      * @param host
      */
-    @Test(priority = 24)
+    @Test(priority = 25)
     @Parameters({"param1"})
     public void httpPut(final String host) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
 
-        ps.append("\n24." + tl.httpPut()[0] + "-" + tl.httpPut()[1]).append("\n");
+        ps.append("\n25." + tl.httpPut()[0] + "-" + tl.httpPut()[1]).append("\n");
         ps.append("Request:\n");
         final String resource =
                 RestAssured.given()
@@ -91,11 +91,11 @@ public class HttpPut {
      * @param host
      * @throws FileNotFoundException
      */
-    @Test(priority = 25)
+    @Test(priority = 26)
     @Parameters({"param1"})
     public void updateTriples(final String host) throws FileNotFoundException {
     final PrintStream ps = TestSuiteGlobals.logFile();
-    ps.append("\n25." + tl.updateTriples()[0] + "-" + tl.updateTriples()[1]).append("\n");
+    ps.append("\n26." + tl.updateTriples()[0] + "-" + tl.updateTriples()[1]).append("\n");
     ps.append("Request:\n");
 
     final String resource =
@@ -130,11 +130,11 @@ public class HttpPut {
      * @param host
      * @throws FileNotFoundException
      */
-    @Test(priority = 26)
+    @Test(priority = 27)
     @Parameters({"param1"})
     public void updateDisallowedTriples(final String host) throws FileNotFoundException {
     final PrintStream ps = TestSuiteGlobals.logFile();
-    ps.append("\n26." + tl.updateDisallowedTriples()[0] + "-" + tl.updateDisallowedTriples()[1]).append("\n");
+    ps.append("\n27." + tl.updateDisallowedTriples()[0] + "-" + tl.updateDisallowedTriples()[1]).append("\n");
     ps.append("Request:\n");
 
     final String resource =
@@ -169,11 +169,11 @@ public class HttpPut {
      * @param host
      * @throws FileNotFoundException
      */
-    @Test(priority = 27)
+    @Test(priority = 28)
     @Parameters({"param1"})
     public void updateDisallowedTriplesResponse(final String host) throws FileNotFoundException {
     final PrintStream ps = TestSuiteGlobals.logFile();
-    ps.append("\n27." + tl.updateDisallowedTriplesResponse()[0] + "-"
+    ps.append("\n28." + tl.updateDisallowedTriplesResponse()[0] + "-"
     + tl.updateDisallowedTriplesResponse()[1]).append("\n");
     ps.append("Request:\n");
 
@@ -209,11 +209,11 @@ public class HttpPut {
      * @param host
      * @throws FileNotFoundException
      */
-    @Test(priority = 28)
+    @Test(priority = 29)
     @Parameters({"param1"})
     public void updateDisallowedTriplesConstrainedByHeader(final String host) throws FileNotFoundException {
     final PrintStream ps = TestSuiteGlobals.logFile();
-    ps.append("\n28." + tl.updateDisallowedTriplesConstrainedByHeader()[0] + "-"
+    ps.append("\n29." + tl.updateDisallowedTriplesConstrainedByHeader()[0] + "-"
     + tl.updateDisallowedTriplesConstrainedByHeader()[1]).append("\n");
     ps.append("Request:\n");
 
@@ -248,12 +248,12 @@ public class HttpPut {
      * 3.6.2-A
      * @param host
      */
-    @Test(priority = 29)
+    @Test(priority = 30)
     @Parameters({"param1"})
     public void httpPutNR(final String host) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
 
-        ps.append("\n29." + tl.httpPutNR()[0] + "-" + tl.httpPutNR()[1]).append("\n");
+        ps.append("\n30." + tl.httpPutNR()[0] + "-" + tl.httpPutNR()[1]).append("\n");
         ps.append("Request:\n");
         final String resource =
                 RestAssured.given()
@@ -282,12 +282,12 @@ public class HttpPut {
      * 3.6.2-B
      * @param host
      */
-    @Test(priority = 30)
+    @Test(priority = 31)
     @Parameters({"param1"})
     public void putDigestResponseHeaderAuthentication(final String host) throws FileNotFoundException {
         final String checksum = "sha1=cb1a576f22e8e3e110611b616e3e2f5ce9bdb941";
         final PrintStream ps = TestSuiteGlobals.logFile();
-        ps.append("\n30." + tl.putDigestResponseHeaderAuthentication()[0] + "-" +
+        ps.append("\n31." + tl.putDigestResponseHeaderAuthentication()[0] + "-" +
         tl.putDigestResponseHeaderAuthentication()[1]).append("\n");
         ps.append("Request:\n");
         final String resource =
@@ -318,12 +318,12 @@ public class HttpPut {
      * 3.6.2-C
      * @param host
      */
-    @Test(priority = 31)
+    @Test(priority = 32)
     @Parameters({"param1"})
     public void putDigestResponseHeaderVerification(final String host) throws FileNotFoundException {
         final String checksum = "abc=abc";
         final PrintStream ps = TestSuiteGlobals.logFile();
-        ps.append("\n31." + tl.putDigestResponseHeaderVerification()[0] + "-" +
+        ps.append("\n32." + tl.putDigestResponseHeaderVerification()[0] + "-" +
         tl.putDigestResponseHeaderVerification()[1]).append("\n");
         ps.append("Request:\n");
         final String resource =


### PR DESCRIPTION
The server must send the same Digest header in the response as it would have sent if the request had been a GET (or omit it if it would have been omitted for a GET).

Minor label updates.

Test 3.2 GET changed numbering to 3.2.2-B GET.