### PR TITLE
Bugfix log file cleanup

### DIFF
--- a/src/main/java/com/ibr/fedora/App.java
+++ b/src/main/java/com/ibr/fedora/App.java
@@ -79,6 +79,7 @@ public class App {
     final Map<String, String> params = new HashMap<String, String>();
     final List<XmlClass> classes = new ArrayList<XmlClass>();
 
+    classes.add(new XmlClass("com.ibr.fedora.testsuite.SetUpSuite"));
     classes.add(new XmlClass("com.ibr.fedora.testsuite.Container"));
     classes.add(new XmlClass("com.ibr.fedora.testsuite.Ldpnr"));
     classes.add(new XmlClass("com.ibr.fedora.testsuite.HttpGet"));

--- a/src/main/java/com/ibr/fedora/testsuite/Container.java
+++ b/src/main/java/com/ibr/fedora/testsuite/Container.java
@@ -75,6 +75,7 @@ public class Container {
     @Test(priority = 1)
     @Parameters({"param1"})
     public void createLDPC(final String host) throws FileNotFoundException {
+        TestSuiteGlobals.resetFile();
         final PrintStream ps = TestSuiteGlobals.logFile();
         ps.append("\n1." + tl.createLDPC()[1]).append("\n");
         ps.append("Request:\n");

--- a/src/main/java/com/ibr/fedora/testsuite/Container.java
+++ b/src/main/java/com/ibr/fedora/testsuite/Container.java
@@ -75,7 +75,6 @@ public class Container {
     @Test(priority = 1)
     @Parameters({"param1"})
     public void createLDPC(final String host) throws FileNotFoundException {
-        TestSuiteGlobals.resetFile();
         final PrintStream ps = TestSuiteGlobals.logFile();
         ps.append("\n1." + tl.createLDPC()[1]).append("\n");
         ps.append("Request:\n");

--- a/src/main/java/com/ibr/fedora/testsuite/Ldpnr.java
+++ b/src/main/java/com/ibr/fedora/testsuite/Ldpnr.java
@@ -59,7 +59,6 @@ public class Ldpnr {
     @Test(priority = 4)
     @Parameters({"param1"})
     public void ldpnrCreationLinkType(final String host) throws FileNotFoundException {
-        TestSuiteGlobals.resetFile();
         final PrintStream ps = TestSuiteGlobals.logFile();
         ps.append("\n4." + tl.ldpnrCreationLinkType()[1]).append("\n");
         ps.append("Request:\n");

--- a/src/main/java/com/ibr/fedora/testsuite/Ldpnr.java
+++ b/src/main/java/com/ibr/fedora/testsuite/Ldpnr.java
@@ -27,14 +27,12 @@ import io.restassured.http.Header;
 import io.restassured.response.Response;
 
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Listeners;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
 import java.io.FileNotFoundException;
 import java.io.PrintStream;
 
-@Listeners({com.ibr.fedora.report.HtmlReporter.class, com.ibr.fedora.report.EarlReporter.class})
 public class Ldpnr {
     public TestsLabels tl = new TestsLabels();
     public String username;

--- a/src/main/java/com/ibr/fedora/testsuite/SetUpSuite.java
+++ b/src/main/java/com/ibr/fedora/testsuite/SetUpSuite.java
@@ -1,0 +1,41 @@
+/**
+ * @author Fernando Cardoza
+ */
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibr.fedora.testsuite;
+
+import java.io.FileNotFoundException;
+
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Listeners;
+
+import com.ibr.fedora.TestSuiteGlobals;
+
+@Listeners({com.ibr.fedora.report.HtmlReporter.class, com.ibr.fedora.report.EarlReporter.class})
+public class SetUpSuite {
+
+    /**
+     * 
+     * @throws FileNotFoundException
+     */
+    @BeforeSuite
+    public void setUp() throws FileNotFoundException {
+        TestSuiteGlobals.resetFile();
+    }
+}


### PR DESCRIPTION
Method included in the Container class instead of the Ldpnr class, to clear the log file in the first test.