### PR TITLE
Add destination of HTML report to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@
 
 A Standalone testing suite that exercises the requirements in the Fedora API Specification indicating the degree of the server’s compliance with the specification.
 
-Requires Maven to generate .jar file
-https://maven.apache.org/install.html
 
-Standalone
+Building the test suite:
 ```
 $ mvn install
-$ mvn package
+```
 
+Running the test suite:
+```
 $ java -jar target/testSuite-1.0-SNAPSHOT-shaded.jar --host http://localhost:8080/
 ```
+
+ Test results are available at:
+ > report/testsuite-execution-report.html

--- a/src/main/java/com/ibr/fedora/report/EarlCoreReporter.java
+++ b/src/main/java/com/ibr/fedora/report/EarlCoreReporter.java
@@ -68,11 +68,10 @@ public abstract class EarlCoreReporter {
     protected void createWriter(final String directory) throws IOException {
         final File dir = new File(directory);
         dir.mkdirs();
-        System.out.println("Writing EARL results:");
+
         final String fileName = TestSuiteGlobals.outputName + "-execution-report-earl.ttl";
         final File file = new File(dir, fileName);
         writer = new BufferedWriter(new FileWriter(file));
-        System.out.println("\t" + file.getAbsolutePath());
     }
 
     protected void write() {

--- a/src/main/java/com/ibr/fedora/report/HtmlReporter.java
+++ b/src/main/java/com/ibr/fedora/report/HtmlReporter.java
@@ -117,12 +117,16 @@ public class HtmlReporter implements IReporter {
 
     private void createWriter(final String output) {
         BufferedWriter writer = null;
-        //String date = TestSuiteGlobals.today();
-        new File(TestSuiteGlobals.outputDirectory).mkdirs();
+        final File dir = new File(TestSuiteGlobals.outputDirectory);
+        dir.mkdirs();
+
+        final String fileName = TestSuiteGlobals.outputName + "-execution-report.html";
+        System.out.println("Writing HTML results:");
         try {
-            writer = new BufferedWriter(new FileWriter(TestSuiteGlobals.outputDirectory + "/" +
-        TestSuiteGlobals.outputName + "-execution-report.html"));
+            final File file = new File(dir, fileName);
+            writer = new BufferedWriter(new FileWriter(file));
             writer.write(output);
+            System.out.println("\t" + file.getAbsolutePath());
 
         } catch (IOException e) {
         } finally {


### PR DESCRIPTION
Change commandline output to mention HTML instead of EARL report

Resolves: https://github.com/fcrepo4-labs/Fedora-API-Test-Suite/issues/20