### PR TITLE
Fixing 3.5 test labels to realign with current specification draft

### DIFF
--- a/src/main/java/com/ibr/fedora/TestsLabels.java
+++ b/src/main/java/com/ibr/fedora/TestsLabels.java
@@ -263,7 +263,7 @@ public TestsLabels() { }
     */
     public String[] postNonRDFSource() {
         return new String[] {
-            "3.5-C - NonRDFSource-PostNonRDFSource",
+            "3.5.1-A - NonRDFSource-PostNonRDFSource",
             "Any LDPC must support creation of LDP-NRs on POST ([LDP] 5.2.3.3 may becomes must).",
             "https://fcrepo.github.io/fcrepo-specification/#http-post",
             "MUST"
@@ -275,7 +275,7 @@ public TestsLabels() { }
     */
     public String[] postResourceAndCheckAssociatedResource() {
         return new String[] {
-            "3.5-D - NonRDFSource-PostResourceAndCheckAssociatedResource",
+            "3.5.1-B - NonRDFSource-PostResourceAndCheckAssociatedResource",
             "On creation of an LDP-NR, an implementation must create an associated LDP-RS describing"
             + " that LDP-NR ([LDP] 5.2.3.12 may becomes must).",
             "https://fcrepo.github.io/fcrepo-specification/#http-post",
@@ -288,7 +288,7 @@ public TestsLabels() { }
     */
     public String[] postDigestResponseHeaderAuthentication() {
         return new String[] {
-            "3.5.1-A - NonRDFSource-PostDigestResponseHeaderAuthentication",
+            "3.5.1-C - NonRDFSource-PostDigestResponseHeaderAuthentication",
             "An HTTP POST request that would create an LDP-NR and includes a Digest header (as described"
             + " in [RFC3230]) for which the instance-digest in that header does not match that of the "
             + "new LDP-NR must be rejected with a 409 Conflict response.",
@@ -302,7 +302,7 @@ public TestsLabels() { }
     */
     public String[] postDigestResponseHeaderVerification() {
         return new String[] {
-            "3.5.1-B - NonRDFSource-PostDigestResponseHeaderVerification",
+            "3.5.1-D - NonRDFSource-PostDigestResponseHeaderVerification",
             "An HTTP POST request that includes an unsupported Digest type (as described in [RFC3230]), "
             + "should be rejected with a 400 Bad Request response.",
             "https://fcrepo.github.io/fcrepo-specification/#http-post-ldpnr",

--- a/src/main/java/com/ibr/fedora/testsuite/HttpPost.java
+++ b/src/main/java/com/ibr/fedora/testsuite/HttpPost.java
@@ -113,7 +113,7 @@ public class HttpPost {
     }
 
     /**
-     * 3.5-C
+     * 3.5.1-A
      * @param uri
      */
     @Test(priority = 22)
@@ -125,7 +125,7 @@ public class HttpPost {
     RestAssured.given()
     .auth().basic(this.username, this.password)
             .header("Content-Disposition", "attachment; filename=\"postNonRDFSource.txt\"")
-            .header("slug", "Post-3.5-C")
+            .header("slug", "Post-3.5.1-A")
             .body("TestString.")
             .config(RestAssured.config().logConfig(new LogConfig().defaultStream(ps)))
             .log().all()
@@ -138,7 +138,7 @@ public class HttpPost {
     }
 
     /**
-     * 3.5-D
+     * 3.5.1-B
      * @param uri
      */
     @Test(priority = 23)
@@ -150,7 +150,7 @@ public class HttpPost {
     RestAssured.given()
     .auth().basic(this.username, this.password)
             .header("Content-Disposition", "attachment; filename=\"postResourceAndCheckAssociatedResource.txt\"")
-            .header("slug", "Post-3.5-D")
+            .header("slug", "Post-3.5.1-B")
             .body("TestString.")
             .config(RestAssured.config().logConfig(new LogConfig().defaultStream(ps)))
             .log().all()
@@ -164,7 +164,7 @@ public class HttpPost {
     }
 
     /**
-     * 3.5.1-A
+     * 3.5.1-C
      * @param uri
      */
     @Test(priority = 24)
@@ -179,7 +179,7 @@ public class HttpPost {
             .auth().basic(this.username, this.password)
             .header("Content-Disposition",
                 "attachment; filename=\"test1digesttext.txt\"")
-            .header("slug", "Post-3.5.1-A")
+            .header("slug", "Post-3.5.1-C")
             .body("TestString.")
             .header("Digest", checksum)
             .config(RestAssured.config().logConfig(new LogConfig().defaultStream(ps)))
@@ -194,7 +194,7 @@ public class HttpPost {
     }
 
     /**
-     * 3.5.1-B
+     * 3.5.1-D
      * @param uri
      */
     @Test(priority = 25)
@@ -209,7 +209,7 @@ public class HttpPost {
             .auth().basic(this.username, this.password)
             .header("Content-Disposition",
                 "attachment; filename=\"test1digesttext2.txt\"")
-            .header("slug", "Post-3.5.1-B")
+            .header("slug", "Post-3.5.1-D")
             .body("TestString.")
             .header("Digest", checksum)
             .config(RestAssured.config().logConfig(new LogConfig().defaultStream(ps)))


### PR DESCRIPTION
TestsLabels class and the HttpPost class needed minor changes to account for some labeling drift in the spec as described in #48 