### PR TITLE
Use default or provided testng.xml instead of hardcoded configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ $ java -jar target/testSuite-1.0-SNAPSHOT-shaded.jar --baseurl http://localhost:
 * `baseurl` The repository base URL, e.g., `http://localhost:8080/rest/`
 * `user` (optional) The username to connect to the repository with
 * `password` (optional) The password to connect to the repository with
+* `testngxml` (optional) The custom testng.xml configuration ([documentation](http://testng.org/doc/documentation-main.html#testng-xml))
+  * See example [testng.xml](https://github.com/fcrepo4-labs/Fedora-API-Test-Suite/tree/master/src/main/resources/testng.xml)
 
  Test results are available at:
  > report/testsuite-execution-report.html

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <commons.cli.version>1.2</commons.cli.version>
     <commons.lang3.version>3.3.2</commons.lang3.version>
     <commons.io.version>2.4</commons.io.version>
-    <testng.version>6.8.8</testng.version>
+    <testng.version>6.10</testng.version>
     <rest.assured.version>3.0.5</rest.assured.version>
     <sesame.model.version>4.1.0</sesame.model.version>
     <jena.arq.version>3.4.0</jena.arq.version>

--- a/src/main/resources/testng.xml
+++ b/src/main/resources/testng.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="W3C Linked Data Platform Test Suite">
-  <listeners>
-    <listener class-name='com.ibr.fedora.report.HtmlReport'/>
-  </listeners>
+<suite name="Fedora API Specification Test Suite">
 
   <test name="All Tests">
     <groups>
@@ -17,4 +14,5 @@
       <package name="com.ibr.fedora.testsuite"/>
     </packages>
   </test>
+
 </suite>


### PR DESCRIPTION
- Upgrade version of testng to 6.10
- Add 'testngxml' commandline option to indicate custom testng.xml
- Update README.md with new user-provided testng.xml option

Resolves: https://github.com/fcrepo4-labs/Fedora-API-Test-Suite/issues/52