### PR TITLE
Enable selective runs of tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ $ java -jar target/testSuite-1.0-SNAPSHOT-shaded.jar --baseurl http://localhost:
 * `password` (optional) The password to connect to the repository with
 * `testngxml` (optional) The custom testng.xml configuration ([documentation](http://testng.org/doc/documentation-main.html#testng-xml))
   * See example [testng.xml](https://github.com/fcrepo4-labs/Fedora-API-Test-Suite/tree/master/src/main/resources/testng.xml)
+* `requirements` (optional) The requirement-levels of test to be run: ALL|MUST|SHOULD|MAY|MUSTNOT|SHOULDNOT
+  * Multiple levels can be provided, separated by ','
 
+### Notes
+* Specific test methods may be invoked by using a custom testng.xml file (option: `testngxml`) with the addition of \<class>/\<methods> regular expression filters.
+ See commented example in [testng.xml](https://github.com/fcrepo4-labs/Fedora-API-Test-Suite/tree/master/src/main/resources/testng.xml)
+
+## Results
  Test results are available at:
  > report/testsuite-execution-report.html

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ $ java -jar target/testSuite-1.0-SNAPSHOT-shaded.jar --baseurl http://localhost:
 * `baseurl` The repository base URL, e.g., `http://localhost:8080/rest/`
 * `user` (optional) The username to connect to the repository with
 * `password` (optional) The password to connect to the repository with
+* `testngxml` (optional) The custom testng.xml configuration ([documentation](http://testng.org/doc/documentation-main.html#testng-xml))
+  * See example [testng.xml](https://github.com/fcrepo4-labs/Fedora-API-Test-Suite/tree/master/src/main/resources/testng.xml)
 
  Test results are available at:
  > report/testsuite-execution-report.html

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <commons.cli.version>1.2</commons.cli.version>
     <commons.lang3.version>3.3.2</commons.lang3.version>
     <commons.io.version>2.4</commons.io.version>
-    <testng.version>6.8.8</testng.version>
+    <testng.version>6.10</testng.version>
     <rest.assured.version>3.0.5</rest.assured.version>
     <sesame.model.version>4.1.0</sesame.model.version>
     <jena.arq.version>3.4.0</jena.arq.version>

--- a/src/main/java/com/ibr/fedora/App.java
+++ b/src/main/java/com/ibr/fedora/App.java
@@ -33,6 +33,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.apache.jena.ext.com.google.common.base.Joiner;
 import org.testng.TestNG;
 import org.testng.xml.SuiteXmlParser;
 import org.testng.xml.XmlSuite;
@@ -60,6 +61,11 @@ public class App {
         final Option testngxml = new Option("x", "testngxml", true, "TestNG XML file");
         testngxml.setRequired(false);
         options.addOption(testngxml);
+        final Option reqs = new Option("r", "requirements", true, "Requirement levels. One or more of the following, " +
+                "separated by ',': [ALL|MUST|SHOULD|MAY|MUSTNOT|SHOULDNOT]");
+        reqs.setRequired(false);
+        reqs.setValueSeparator(',');;
+        options.addOption(reqs);
 
         final CommandLineParser parser = new BasicParser();
         final HelpFormatter formatter = new HelpFormatter();
@@ -77,6 +83,7 @@ public class App {
         final String inputUser = cmd.getOptionValue("user") == null ? "" : cmd.getOptionValue("user");
         final String inputPassword = cmd.getOptionValue("password") == null ? "" : cmd.getOptionValue("password");
         final String inputXml = cmd.getOptionValue("testngxml");
+        final String[] requirements = cmd.getOptionValues("requirements");
 
         //Create the default container
         final Map<String, String> params = new HashMap<>();
@@ -103,6 +110,11 @@ public class App {
 
         final TestNG testng = new TestNG();
         testng.setCommandLineSuite(xmlSuite);
+
+        // Set requirement-level groups to be run
+        if (requirements != null && requirements.length > 0) {
+            testng.setGroups(Joiner.on(',').join(requirements).toLowerCase());
+        }
 
         testng.run();
     }

--- a/src/main/java/com/ibr/fedora/testsuite/Container.java
+++ b/src/main/java/com/ibr/fedora/testsuite/Container.java
@@ -31,7 +31,6 @@ import io.restassured.http.Header;
 import io.restassured.http.Headers;
 import io.restassured.response.Response;
 import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
@@ -69,9 +68,8 @@ public class Container {
      * @param username
      * @param password
      */
-    @BeforeClass
     @Parameters({"param2", "param3"})
-    public void auth(final String username, final String password) {
+    public Container(final String username, final String password) {
         this.username = username;
         this.password = password;
     }
@@ -81,7 +79,7 @@ public class Container {
      *
      * @param uri
      */
-    @Test(priority = 1)
+    @Test(priority = 1, groups = {"MUST"})
     @Parameters({"param1"})
     public void createLDPC(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -108,7 +106,7 @@ public class Container {
      *
      * @param uri
      */
-    @Test(priority = 2)
+    @Test(priority = 2, groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpcContainmentTriples(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -187,7 +185,7 @@ public class Container {
      *
      * @param uri
      */
-    @Test(priority = 3)
+    @Test(priority = 3, groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpcMembershipTriples(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -263,7 +261,7 @@ public class Container {
      *
      * @param uri
      */
-    @Test(priority = 4)
+    @Test(priority = 4, groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpcMinimalContainerTriples(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();

--- a/src/main/java/com/ibr/fedora/testsuite/ExternalBinaryContent.java
+++ b/src/main/java/com/ibr/fedora/testsuite/ExternalBinaryContent.java
@@ -39,7 +39,6 @@ import io.restassured.http.Headers;
 import io.restassured.response.Response;
 import org.testng.Assert;
 import org.testng.SkipException;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
@@ -59,9 +58,8 @@ public class ExternalBinaryContent {
      * @param username
      * @param password
      */
-    @BeforeClass
     @Parameters({"param2", "param3"})
-    public void auth(final String username, final String password) {
+    public ExternalBinaryContent(final String username, final String password) {
         this.username = username;
         this.password = password;
     }
@@ -71,7 +69,7 @@ public class ExternalBinaryContent {
      *
      * @param uri
      */
-    @Test(priority = 45)
+    @Test(priority = 45, groups = {"SHOULD"})
     @Parameters({"param1"})
     public void postCreateExternalBinaryContent(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -105,7 +103,7 @@ public class ExternalBinaryContent {
      *
      * @param uri
      */
-    @Test(priority = 46)
+    @Test(priority = 46, groups = {"SHOULD"})
     @Parameters({"param1"})
     public void putCreateExternalBinaryContent(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -139,7 +137,7 @@ public class ExternalBinaryContent {
      *
      * @param uri
      */
-    @Test(priority = 47)
+    @Test(priority = 47, groups = {"SHOULD"})
     @Parameters({"param1"})
     public void putUpdateExternalBinaryContent(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -192,7 +190,7 @@ public class ExternalBinaryContent {
      *
      * @param uri
      */
-    @Test(priority = 48)
+    @Test(priority = 48, groups = {"MUST"})
     @Parameters({"param1"})
     public void createExternalBinaryContentCheckAccesType(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -226,7 +224,7 @@ public class ExternalBinaryContent {
      *
      * @param uri
      */
-    @Test(priority = 49)
+    @Test(priority = 49, groups = {"MUST"})
     @Parameters({"param1"})
     public void postCheckUnsupportedMediaType(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -253,7 +251,7 @@ public class ExternalBinaryContent {
      *
      * @param uri
      */
-    @Test(priority = 50)
+    @Test(priority = 50, groups = {"MUST"})
     @Parameters({"param1"})
     public void putCheckUnsupportedMediaType(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -280,7 +278,7 @@ public class ExternalBinaryContent {
      *
      * @param uri
      */
-    @Test(priority = 51)
+    @Test(priority = 51, groups = {"MUST"})
     @Parameters({"param1"})
     public void checkUnsupportedMediaType(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -332,7 +330,7 @@ public class ExternalBinaryContent {
      *
      * @param uri
      */
-    @Test(priority = 52)
+    @Test(priority = 52, groups = {"MUST NOT"})
     @Parameters({"param1"})
     public void postCheckHeaders(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -408,7 +406,7 @@ public class ExternalBinaryContent {
      *
      * @param uri
      */
-    @Test(priority = 53)
+    @Test(priority = 53, groups = {"MUST NOT"})
     @Parameters({"param1"})
     public void putUpdateCheckHeaders(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -510,7 +508,7 @@ public class ExternalBinaryContent {
      *
      * @param uri
      */
-    @Test(priority = 54)
+    @Test(priority = 54, groups = {"SHOULD"})
     @Parameters({"param1"})
     public void getCheckContentLocationHeader(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -576,7 +574,7 @@ public class ExternalBinaryContent {
      *
      * @param uri
      */
-    @Test(priority = 55)
+    @Test(priority = 55, groups = {"SHOULD"})
     @Parameters({"param1"})
     public void headCheckContentLocationHeader(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -642,7 +640,7 @@ public class ExternalBinaryContent {
      *
      * @param uri
      */
-    @Test(priority = 56)
+    @Test(priority = 56, groups = {"MUST"})
     @Parameters({"param1"})
     public void respondWantDigestExternalBinaryContent(final String uri) throws FileNotFoundException {
         final String checksum = "md5";
@@ -688,7 +686,7 @@ public class ExternalBinaryContent {
      *
      * @param uri
      */
-    @Test(priority = 57)
+    @Test(priority = 57, groups = {"MUST"})
     @Parameters({"param1"})
     public void respondWantDigestExternalBinaryContentHead(final String uri) throws FileNotFoundException {
         final String checksum = "md5";
@@ -734,7 +732,7 @@ public class ExternalBinaryContent {
      *
      * @param uri
      */
-    @Test(priority = 58)
+    @Test(priority = 58, groups = {"MUST"})
     @Parameters({"param1"})
     public void respondWantDigestTwoSupportedExternalBinaryContent(final String uri) throws FileNotFoundException {
         final String checksum = "md5,sha";
@@ -788,7 +786,7 @@ public class ExternalBinaryContent {
      *
      * @param uri
      */
-    @Test(priority = 59)
+    @Test(priority = 59, groups = {"MUST"})
     @Parameters({"param1"})
     public void respondWantDigestTwoSupportedExternalBinaryContentHead(final String uri) throws FileNotFoundException {
         final String checksum = "md5,sha";
@@ -843,7 +841,7 @@ public class ExternalBinaryContent {
      *
      * @param uri
      */
-    @Test(priority = 60)
+    @Test(priority = 60, groups = {"MUST"})
     @Parameters({"param1"})
     public void respondWantDigestTwoSupportedQvalueNonZeroExternalBinaryContent(final String uri)
         throws FileNotFoundException {
@@ -899,7 +897,7 @@ public class ExternalBinaryContent {
      *
      * @param uri
      */
-    @Test(priority = 61)
+    @Test(priority = 61, groups = {"MUST"})
     @Parameters({"param1"})
     public void respondWantDigestTwoSupportedQvalueNonZeroExternalBinaryContentHead(final String uri)
         throws FileNotFoundException {
@@ -955,7 +953,7 @@ public class ExternalBinaryContent {
      *
      * @param uri
      */
-    @Test(priority = 62)
+    @Test(priority = 62, groups = {"MUST"})
     @Parameters({"param1"})
     public void respondWantDigestNonSupportedExternalBinaryContent(final String uri)
         throws FileNotFoundException {
@@ -1002,7 +1000,7 @@ public class ExternalBinaryContent {
      *
      * @param uri
      */
-    @Test(priority = 63)
+    @Test(priority = 63, groups = {"MUST"})
     @Parameters({"param1"})
     public void respondWantDigestNonSupportedExternalBinaryContentHead(final String uri)
         throws FileNotFoundException {

--- a/src/main/java/com/ibr/fedora/testsuite/HttpDelete.java
+++ b/src/main/java/com/ibr/fedora/testsuite/HttpDelete.java
@@ -31,7 +31,6 @@ import io.restassured.http.Header;
 import io.restassured.http.Headers;
 import io.restassured.response.Response;
 import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
@@ -51,9 +50,8 @@ public class HttpDelete {
      * @param username
      * @param password
      */
-    @BeforeClass
     @Parameters({"param2", "param3"})
-    public void auth(final String username, final String password) {
+    public HttpDelete(final String username, final String password) {
         this.username = username;
         this.password = password;
     }
@@ -63,7 +61,7 @@ public class HttpDelete {
      *
      * @param uri
      */
-    @Test(priority = 42)
+    @Test(priority = 42, groups = {"SHOULD NOT"})
     @Parameters({"param1"})
     public void httpDeleteOptionsCheck(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -207,7 +205,7 @@ public class HttpDelete {
      *
      * @param uri
      */
-    @Test(priority = 43)
+    @Test(priority = 43, groups = {"MUST NOT"})
     @Parameters({"param1"})
     public void httpDeleteStatusCheck(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -335,7 +333,7 @@ public class HttpDelete {
      *
      * @param uri
      */
-    @Test(priority = 44)
+    @Test(priority = 44, groups = {"MUST NOT"})
     @Parameters({"param1"})
     public void httpDeleteStatusCheckTwo(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();

--- a/src/main/java/com/ibr/fedora/testsuite/HttpGet.java
+++ b/src/main/java/com/ibr/fedora/testsuite/HttpGet.java
@@ -33,7 +33,6 @@ import io.restassured.http.Header;
 import io.restassured.http.Headers;
 import io.restassured.response.Response;
 import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
@@ -53,9 +52,8 @@ public class HttpGet {
      * @param username
      * @param password
      */
-    @BeforeClass
     @Parameters({"param2", "param3"})
-    public void auth(final String username, final String password) {
+    public HttpGet(final String username, final String password) {
         this.username = username;
         this.password = password;
     }
@@ -65,7 +63,7 @@ public class HttpGet {
      *
      * @param uri
      */
-    @Test(priority = 7)
+    @Test(priority = 7, groups = {"MAY"})
     @Parameters({"param1"})
     public void additionalValuesForPreferHeader(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -104,7 +102,7 @@ public class HttpGet {
      *
      * @param uri
      */
-    @Test(priority = 8)
+    @Test(priority = 8, groups = {"MUST"})
     @Parameters({"param1"})
     public void responsePreferenceAppliedHeader(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -140,7 +138,7 @@ public class HttpGet {
      *
      * @param uri
      */
-    @Test(priority = 9)
+    @Test(priority = 9, groups = {"MUST"})
     @Parameters({"param1"})
     public void responseDescribesHeader(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -174,7 +172,7 @@ public class HttpGet {
      *
      * @param uri
      */
-    @Test(priority = 10)
+    @Test(priority = 10, groups = {"MUST"})
     @Parameters({"param1"})
     public void respondWantDigest(final String uri) throws FileNotFoundException {
         final String checksum = "md5";
@@ -212,7 +210,7 @@ public class HttpGet {
      *
      * @param uri
      */
-    @Test(priority = 11)
+    @Test(priority = 11, groups = {"MUST"})
     @Parameters({"param1"})
     public void respondWantDigestTwoSupported(final String uri) throws FileNotFoundException {
         final String checksum = "md5,sha";
@@ -258,7 +256,7 @@ public class HttpGet {
      *
      * @param uri
      */
-    @Test(priority = 12)
+    @Test(priority = 12, groups = {"MUST"})
     @Parameters({"param1"})
     public void respondWantDigestTwoSupportedQvalueNonZero(final String uri) throws FileNotFoundException {
         final String checksum = "md5;q=0.3,sha;q=1";
@@ -304,7 +302,7 @@ public class HttpGet {
      *
      * @param uri
      */
-    @Test(priority = 13)
+    @Test(priority = 13, groups = {"MUST"})
     @Parameters({"param1"})
     public void respondWantDigestTwoSupportedQvalueZero(final String uri) throws FileNotFoundException {
         final String checksum = "md5;q=0.3,sha;q=0";
@@ -342,7 +340,7 @@ public class HttpGet {
      *
      * @param uri
      */
-    @Test(priority = 14)
+    @Test(priority = 14, groups = {"MUST"})
     @Parameters({"param1"})
     public void respondWantDigestNonSupported(final String uri) throws FileNotFoundException {
         final String checksum = "md5,abc";

--- a/src/main/java/com/ibr/fedora/testsuite/HttpHead.java
+++ b/src/main/java/com/ibr/fedora/testsuite/HttpHead.java
@@ -35,7 +35,6 @@ import io.restassured.http.Header;
 import io.restassured.http.Headers;
 import io.restassured.response.Response;
 import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
@@ -55,9 +54,8 @@ public class HttpHead {
      * @param username
      * @param password
      */
-    @BeforeClass
     @Parameters({"param2", "param3"})
-    public void auth(final String username, final String password) {
+    public HttpHead(final String username, final String password) {
         this.username = username;
         this.password = password;
     }
@@ -67,7 +65,7 @@ public class HttpHead {
      *
      * @param uri
      */
-    @Test(priority = 15)
+    @Test(priority = 15, groups = {"MUST NOT"})
     @Parameters({"param1"})
     public void httpHeadResponseNoBody(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -102,7 +100,7 @@ public class HttpHead {
      *
      * @param uri
      */
-    @Test(priority = 16)
+    @Test(priority = 16, groups = {"MUST"})
     @Parameters({"param1"})
     public void httpHeadResponseDigest(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -175,7 +173,7 @@ public class HttpHead {
      *
      * @param uri
      */
-    @Test(priority = 17)
+    @Test(priority = 17, groups = {"SHOULD"})
     @Parameters({"param1"})
     public void httpHeadResponseHeadersSameAsHttpGet(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();

--- a/src/main/java/com/ibr/fedora/testsuite/HttpOptions.java
+++ b/src/main/java/com/ibr/fedora/testsuite/HttpOptions.java
@@ -29,7 +29,6 @@ import com.ibr.fedora.TestSuiteGlobals;
 import com.ibr.fedora.TestsLabels;
 import io.restassured.RestAssured;
 import io.restassured.config.LogConfig;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
@@ -44,9 +43,8 @@ public class HttpOptions {
      * @param username
      * @param password
      */
-    @BeforeClass
     @Parameters({"param2", "param3"})
-    public void auth(final String username, final String password) {
+    public HttpOptions(final String username, final String password) {
         this.username = username;
         this.password = password;
     }
@@ -56,7 +54,7 @@ public class HttpOptions {
      *
      * @param uri
      */
-    @Test(priority = 18)
+    @Test(priority = 18, groups = {"MUST"})
     @Parameters({"param1"})
     public void httpOptionsSupport(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -81,7 +79,7 @@ public class HttpOptions {
      *
      * @param uri
      */
-    @Test(priority = 19)
+    @Test(priority = 19, groups = {"MUST"})
     @Parameters({"param1"})
     public void httpOptionsSupportAllow(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();

--- a/src/main/java/com/ibr/fedora/testsuite/HttpPatch.java
+++ b/src/main/java/com/ibr/fedora/testsuite/HttpPatch.java
@@ -35,7 +35,6 @@ import io.restassured.http.ContentType;
 import io.restassured.http.Header;
 import io.restassured.http.Headers;
 import io.restassured.response.Response;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
@@ -80,9 +79,8 @@ public class HttpPatch {
      * @param username
      * @param password
      */
-    @BeforeClass
     @Parameters({"param2", "param3"})
-    public void auth(final String username, final String password) {
+    public HttpPatch(final String username, final String password) {
         this.username = username;
         this.password = password;
     }
@@ -92,7 +90,7 @@ public class HttpPatch {
      *
      * @param uri
      */
-    @Test(priority = 34)
+    @Test(priority = 34, groups = {"MUST"})
     @Parameters({"param1"})
     public void supportPatch(final String uri) throws IOException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -133,7 +131,7 @@ public class HttpPatch {
      *
      * @param uri
      */
-    @Test(priority = 35)
+    @Test(priority = 35, groups = {"MAY"})
     @Parameters({"param1"})
     public void ldpPatchContentTypeSupport(final String uri) throws IOException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -173,7 +171,7 @@ public class HttpPatch {
      *
      * @param uri
      */
-    @Test(priority = 36)
+    @Test(priority = 36, groups = {"MUST"})
     @Parameters({"param1"})
     public void serverManagedPropertiesModification(final String uri) throws IOException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -214,7 +212,7 @@ public class HttpPatch {
      *
      * @param uri
      */
-    @Test(priority = 37)
+    @Test(priority = 37, groups = {"MUST"})
     @Parameters({"param1"})
     public void statementNotPersistedResponseBody(final String uri) throws IOException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -255,7 +253,7 @@ public class HttpPatch {
      *
      * @param uri
      */
-    @Test(priority = 38)
+    @Test(priority = 38, groups = {"MUST"})
     @Parameters({"param1"})
     public void statementNotPersistedConstrainedBy(final String uri) throws IOException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -296,7 +294,7 @@ public class HttpPatch {
      *
      * @param uri
      */
-    @Test(priority = 39)
+    @Test(priority = 39, groups = {"MUST"})
     @Parameters({"param1"})
     public void successfulPatchStatusCode(final String uri) throws IOException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -363,7 +361,7 @@ public class HttpPatch {
      *
      * @param uri
      */
-    @Test(priority = 40)
+    @Test(priority = 40, groups = {"MUST"})
     @Parameters({"param1"})
     public void disallowPatchContainmentTriples(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -413,7 +411,7 @@ public class HttpPatch {
      *
      * @param uri
      */
-    @Test(priority = 41)
+    @Test(priority = 41, groups = {"MUST"})
     @Parameters({"param1"})
     public void disallowChangeResourceType(final String uri) throws IOException {
         final PrintStream ps = TestSuiteGlobals.logFile();

--- a/src/main/java/com/ibr/fedora/testsuite/HttpPost.java
+++ b/src/main/java/com/ibr/fedora/testsuite/HttpPost.java
@@ -29,7 +29,6 @@ import com.ibr.fedora.TestSuiteGlobals;
 import com.ibr.fedora.TestsLabels;
 import io.restassured.RestAssured;
 import io.restassured.config.LogConfig;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
@@ -52,9 +51,8 @@ public class HttpPost {
      * @param username
      * @param password
      */
-    @BeforeClass
     @Parameters({"param2", "param3"})
-    public void auth(final String username, final String password) {
+    public HttpPost(final String username, final String password) {
         this.username = username;
         this.password = password;
     }
@@ -64,7 +62,7 @@ public class HttpPost {
      *
      * @param uri
      */
-    @Test(priority = 20)
+    @Test(priority = 20, groups = {"MUST"})
     @Parameters({"param1"})
     public void httpPost(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -91,7 +89,7 @@ public class HttpPost {
      *
      * @param uri
      */
-    @Test(priority = 21)
+    @Test(priority = 21, groups = {"MUST"})
     @Parameters({"param1"})
     public void constrainedByResponseHeader(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -119,7 +117,7 @@ public class HttpPost {
      *
      * @param uri
      */
-    @Test(priority = 22)
+    @Test(priority = 22, groups = {"MUST"})
     @Parameters({"param1"})
     public void postNonRDFSource(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -145,7 +143,7 @@ public class HttpPost {
      *
      * @param uri
      */
-    @Test(priority = 23)
+    @Test(priority = 23, groups = {"MUST"})
     @Parameters({"param1"})
     public void postResourceAndCheckAssociatedResource(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -172,7 +170,7 @@ public class HttpPost {
      *
      * @param uri
      */
-    @Test(priority = 24)
+    @Test(priority = 24, groups = {"MUST"})
     @Parameters({"param1"})
     public void postDigestResponseHeaderAuthentication(final String uri) throws FileNotFoundException {
         final String checksum = "md5=1234";
@@ -203,7 +201,7 @@ public class HttpPost {
      *
      * @param uri
      */
-    @Test(priority = 25)
+    @Test(priority = 25, groups = {"SHOULD"})
     @Parameters({"param1"})
     public void postDigestResponseHeaderVerification(final String uri) throws FileNotFoundException {
         final String checksum = "abc=abc";

--- a/src/main/java/com/ibr/fedora/testsuite/HttpPut.java
+++ b/src/main/java/com/ibr/fedora/testsuite/HttpPut.java
@@ -30,7 +30,6 @@ import com.ibr.fedora.TestsLabels;
 import io.restassured.RestAssured;
 import io.restassured.config.LogConfig;
 import io.restassured.response.Response;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
@@ -50,9 +49,8 @@ public class HttpPut {
      * @param username
      * @param password
      */
-    @BeforeClass
     @Parameters({"param2", "param3"})
-    public void auth(final String username, final String password) {
+    public HttpPut(final String username, final String password) {
         this.username = username;
         this.password = password;
     }
@@ -62,7 +60,7 @@ public class HttpPut {
      *
      * @param uri
      */
-    @Test(priority = 26)
+    @Test(priority = 26, groups = {"MAY"})
     @Parameters({"param1"})
     public void httpPut(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -98,7 +96,7 @@ public class HttpPut {
      * @param uri
      * @throws FileNotFoundException
      */
-    @Test(priority = 27)
+    @Test(priority = 27, groups = {"MUST"})
     @Parameters({"param1"})
     public void updateTriples(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -144,7 +142,7 @@ public class HttpPut {
      * @param uri
      * @throws FileNotFoundException
      */
-    @Test(priority = 28)
+    @Test(priority = 28, groups = {"MUST"})
     @Parameters({"param1"})
     public void updateDisallowedTriples(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -198,7 +196,7 @@ public class HttpPut {
      * @param uri
      * @throws FileNotFoundException
      */
-    @Test(priority = 29)
+    @Test(priority = 29, groups = {"MUST"})
     @Parameters({"param1"})
     public void updateDisallowedTriplesResponse(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -254,7 +252,7 @@ public class HttpPut {
      * @param uri
      * @throws FileNotFoundException
      */
-    @Test(priority = 30)
+    @Test(priority = 30, groups = {"MUST"})
     @Parameters({"param1"})
     public void updateDisallowedTriplesConstrainedByHeader(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -309,7 +307,7 @@ public class HttpPut {
      *
      * @param uri
      */
-    @Test(priority = 31)
+    @Test(priority = 31, groups = {"MUST"})
     @Parameters({"param1"})
     public void httpPutNR(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -344,7 +342,7 @@ public class HttpPut {
      *
      * @param uri
      */
-    @Test(priority = 32)
+    @Test(priority = 32, groups = {"MUST"})
     @Parameters({"param1"})
     public void putDigestResponseHeaderAuthentication(final String uri) throws FileNotFoundException {
         final String checksum = "MD5=97c4627dc7734f65f5195f1d5f556d7a";
@@ -382,7 +380,7 @@ public class HttpPut {
      *
      * @param uri
      */
-    @Test(priority = 33)
+    @Test(priority = 33, groups = {"SHOULD"})
     @Parameters({"param1"})
     public void putDigestResponseHeaderVerification(final String uri) throws FileNotFoundException {
         final String checksum = "abc=abc";

--- a/src/main/java/com/ibr/fedora/testsuite/Ldpnr.java
+++ b/src/main/java/com/ibr/fedora/testsuite/Ldpnr.java
@@ -30,7 +30,6 @@ import io.restassured.config.LogConfig;
 import io.restassured.http.Header;
 import io.restassured.response.Response;
 import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
@@ -50,9 +49,8 @@ public class Ldpnr {
      * @param username
      * @param password
      */
-    @BeforeClass
     @Parameters({"param2", "param3"})
-    public void auth(final String username, final String password) {
+    public Ldpnr(final String username, final String password) {
         this.username = username;
         this.password = password;
     }
@@ -62,7 +60,7 @@ public class Ldpnr {
      *
      * @param uri
      */
-    @Test(priority = 5)
+    @Test(priority = 5, groups = {"SHOULD"})
     @Parameters({"param1"})
     public void ldpnrCreationLinkType(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();
@@ -133,7 +131,7 @@ public class Ldpnr {
      *
      * @param uri
      */
-    @Test(priority = 6)
+    @Test(priority = 6, groups = {"SHOULD"})
     @Parameters({"param1"})
     public void ldpnrCreationWrongLinkType(final String uri) throws FileNotFoundException {
         final PrintStream ps = TestSuiteGlobals.logFile();

--- a/src/main/java/com/ibr/fedora/testsuite/SetUpSuite.java
+++ b/src/main/java/com/ibr/fedora/testsuite/SetUpSuite.java
@@ -24,9 +24,7 @@ import java.io.FileNotFoundException;
 
 import com.ibr.fedora.TestSuiteGlobals;
 import org.testng.annotations.BeforeSuite;
-import org.testng.annotations.Listeners;
 
-@Listeners({com.ibr.fedora.report.HtmlReporter.class, com.ibr.fedora.report.EarlReporter.class})
 public class SetUpSuite {
 
     /**

--- a/src/main/resources/testng.xml
+++ b/src/main/resources/testng.xml
@@ -2,17 +2,61 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite name="Fedora API Specification Test Suite">
 
-  <test name="All Tests">
+  <listeners>
+    <listener class-name='com.ibr.fedora.report.HtmlReporter'/>
+    <listener class-name="com.ibr.fedora.report.EarlReporter"/>
+  </listeners>
+
+  <!--Set console logging with 'verbose' values from 1-10 (10 is most verbose)-->
+  <test name="Fedora API Specification Tests" verbose="1">
+
     <groups>
-      <define name="allRequirementLevels">
+      <define name="all">
         <include name="MUST"/>
         <include name="SHOULD"/>
         <include name="MAY"/>
+        <include name="MUST NOT"/>
+        <include name="SHOULD NOT"/>
+      </define>
+      <define name="must">
+        <include name="MUST"/>
+      </define>
+      <define name="should">
+        <include name="SHOULD"/>
+      </define>
+      <define name="may">
+        <include name="MAY"/>
+      </define>
+      <define name="mustnot">
+        <include name="MUST NOT"/>
+      </define>
+      <define name="shouldnot">
+        <include name="SHOULD NOT"/>
       </define>
     </groups>
-    <packages>
-      <package name="com.ibr.fedora.testsuite"/>
-    </packages>
+
+    <classes>
+      <class name="com.ibr.fedora.testsuite.SetUpSuite"/>
+      <class name="com.ibr.fedora.testsuite.Container">
+        <!--Specify methods to 'include' or 'exclude'-->
+        <!--
+        <methods>
+          <include name=".*ldpcMembershipTriples.*"/>
+          <include name=".*ldpcMinimalContainerTriples.*"/>
+        </methods>
+        -->
+      </class>
+      <class name="com.ibr.fedora.testsuite.Ldpnr"/>
+      <class name="com.ibr.fedora.testsuite.HttpGet"/>
+      <class name="com.ibr.fedora.testsuite.HttpHead"/>
+      <class name="com.ibr.fedora.testsuite.HttpOptions"/>
+      <class name="com.ibr.fedora.testsuite.HttpPost"/>
+      <class name="com.ibr.fedora.testsuite.HttpPut"/>
+      <class name="com.ibr.fedora.testsuite.HttpPatch"/>
+      <class name="com.ibr.fedora.testsuite.HttpDelete"/>
+      <class name="com.ibr.fedora.testsuite.ExternalBinaryContent"/>
+    </classes>
+
   </test>
 
 </suite>

--- a/src/main/resources/testng.xml
+++ b/src/main/resources/testng.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="W3C Linked Data Platform Test Suite">
-  <listeners>
-    <listener class-name='com.ibr.fedora.report.HtmlReport'/>
-  </listeners>
+<suite name="Fedora API Specification Test Suite">
 
   <test name="All Tests">
     <groups>
@@ -17,4 +14,5 @@
       <package name="com.ibr.fedora.testsuite"/>
     </packages>
   </test>
+
 </suite>


### PR DESCRIPTION
- Select by requirement-level (MUST, MAY, SHOULD, etc)
- Select by method name

Allow for disabling report listeners by moving config to testng.xml
Load credentials via constructors instead of @BeforeClass methods
Update README.md with new requirements-level option

Depends on: https://github.com/fcrepo4-labs/Fedora-API-Test-Suite/pull/53
Resolves: https://github.com/fcrepo4-labs/Fedora-API-Test-Suite/issues/42 and   https://github.com/fcrepo4-labs/Fedora-API-Test-Suite/issues/32
