### PR TITLE
Some tweaks

### DIFF
--- a/src/main/java/com/ibr/fedora/TestSuiteGlobals.java
+++ b/src/main/java/com/ibr/fedora/TestSuiteGlobals.java
@@ -88,7 +88,7 @@ public abstract class TestSuiteGlobals {
      */
     public static boolean checkPayloadHeader(final String header) {
         boolean isPayloadHeader = false;
-        for (String h : payloadHeaders) {
+        for (final String h : payloadHeaders) {
             if (h.equals(header)) {
                 isPayloadHeader = true;
                 break;
@@ -103,7 +103,7 @@ public abstract class TestSuiteGlobals {
      */
     public static boolean checkMembershipTriple(final String body) {
         boolean isMembershipTriple = false;
-        for (String h : membershipTriples) {
+        for (final String h : membershipTriples) {
             if (body.contains(h)) {
                 isMembershipTriple = true;
             }
@@ -167,10 +167,10 @@ public abstract class TestSuiteGlobals {
                                                           final IResultMap skipped, final IResultMap failed)
         throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
         final TreeMap<String, String[]> results = new TreeMap<>();
-        for (ITestResult result : passed.getAllResults()) {
+        final Object o = TestsLabels.class.newInstance();
+        for (final ITestResult result : passed.getAllResults()) {
             final ITestNGMethod method = result.getMethod();
 
-            final Object o = TestsLabels.class.newInstance();
             final Method m = TestsLabels.class.getDeclaredMethod(method.getMethodName());
             final Object[] normalizedName = (Object[]) m.invoke(o);
 
@@ -182,10 +182,9 @@ public abstract class TestSuiteGlobals {
             details[4] = getStackTrace(result.getThrowable());
             results.put(details[3], details);
         }
-        for (ITestResult result : skipped.getAllResults()) {
+        for (final ITestResult result : skipped.getAllResults()) {
             final ITestNGMethod method = result.getMethod();
 
-            final Object o = TestsLabels.class.newInstance();
             final Method m = TestsLabels.class.getDeclaredMethod(method.getMethodName());
             final Object[] normalizedName = (Object[]) m.invoke(o);
 
@@ -197,10 +196,9 @@ public abstract class TestSuiteGlobals {
             details[4] = getStackTrace(result.getThrowable());
             results.put(details[3], details);
         }
-        for (ITestResult result : failed.getAllResults()) {
+        for (final ITestResult result : failed.getAllResults()) {
             final ITestNGMethod method = result.getMethod();
 
-            final Object o = TestsLabels.class.newInstance();
             final Method m = TestsLabels.class.getDeclaredMethod(method.getMethodName());
             final Object[] normalizedName = (Object[]) m.invoke(o);
 
@@ -226,7 +224,7 @@ public abstract class TestSuiteGlobals {
             if (thrown.getClass().getName().contains("TEST SKIPPED")) {
                 msg = thrown.getMessage();
             } else {
-                msg = Utils.stackTrace(thrown, false)[0];
+                msg = Utils.shortStackTrace(thrown, false);
             }
         }
 


### PR DESCRIPTION
It seems we don't need to instantiate
```
final Object o = TestsLabels.class.newInstance();
```
In each loop of all 3 different loops, so instead do it once.

Also due to changing the version  of TestNG in https://github.com/fcrepo4-labs/Fedora-API-Test-Suite/commit/729fa32dbe0cfe15352a89c93c1889c63bdf0268 the TestNG `Utils.stackTrace()` is deprecated so use the preferred `Utils.shortStackTrace()` which is what we were getting before.
