### PR TITLE
Remove unnecessary .* from method name matches

### DIFF
--- a/src/main/resources/testng.xml
+++ b/src/main/resources/testng.xml
@@ -41,8 +41,8 @@
         <!--Specify methods to 'include' or 'exclude'-->
         <!--
         <methods>
-          <include name=".*ldpcMembershipTriples.*"/>
-          <include name=".*ldpcMinimalContainerTriples.*"/>
+          <include name="ldpcMembershipTriples"/>
+          <include name="ldpcMinimalContainerTriples"/>
         </methods>
         -->
       </class>


### PR DESCRIPTION
Just checked out the specific test config (which is great! if a little cumbersome) and notice that bare method names are the simplest thing to use so I suggest that should be the example