### PR TITLE
Places the class level  javadoc comment blocks in the proper place.

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/App.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/App.java
@@ -1,6 +1,3 @@
-/**
- * @author Jorge Abrego, Fernando Cardoza
- */
 /*
  * Licensed to DuraSpace under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
@@ -38,6 +35,10 @@ import org.testng.TestNG;
 import org.testng.xml.SuiteXmlParser;
 import org.testng.xml.XmlSuite;
 
+/**
+ *
+ * @author Jorge Abrego, Fernando Cardoza
+ */
 public class App {
     private App() {
     }

--- a/src/main/java/org/fcrepo/spec/testsuite/TestSuiteGlobals.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/TestSuiteGlobals.java
@@ -1,6 +1,3 @@
-/**
- * @author Jorge Abrego, Fernando Cardoza
- */
 /*
  * Licensed to DuraSpace under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
@@ -38,6 +35,10 @@ import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.internal.Utils;
 
+/**
+ *
+ * @author Jorge Abrego, Fernando Cardoza
+ */
 public abstract class TestSuiteGlobals {
     public static String cssReport = "reportStyle.css";
     public static String outputDirectory = "report";

--- a/src/main/java/org/fcrepo/spec/testsuite/TestsLabels.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/TestsLabels.java
@@ -1,6 +1,3 @@
-/**
- * @author Jorge Abrego, Fernando Cardoza
- */
 /*
  * Licensed to DuraSpace under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
@@ -20,6 +17,10 @@
  */
 package org.fcrepo.spec.testsuite;
 
+/**
+ *
+ * @author Jorge Abrego, Fernando Cardoza
+ */
 public class TestsLabels {
     /**
      * Constructor

--- a/src/main/java/org/fcrepo/spec/testsuite/report/EarlCoreReporter.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/report/EarlCoreReporter.java
@@ -1,6 +1,3 @@
-/**
- * @author Jorge Abrego, Fernando Cardoza
- */
 /*
  * Licensed to DuraSpace under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
@@ -35,6 +32,10 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.openrdf.model.vocabulary.EARL;
 
+/**
+ *
+ * @author Jorge Abrego, Fernando Cardoza
+ */
 public abstract class EarlCoreReporter {
     //Earl resources
     public final static Resource Assertion = ResourceFactory.createResource(EARL.ASSERTION.toString());

--- a/src/main/java/org/fcrepo/spec/testsuite/report/EarlReporter.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/report/EarlReporter.java
@@ -1,6 +1,3 @@
-/**
- * @author Jorge Abrego, Fernando Cardoza
- */
 /*
  * Licensed to DuraSpace under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
@@ -37,6 +34,10 @@ import org.testng.ISuiteResult;
 import org.testng.ITestContext;
 import org.testng.xml.XmlSuite;
 
+/**
+ *
+ * @author Jorge Abrego, Fernando Cardoza
+ */
 public class EarlReporter extends EarlCoreReporter implements IReporter {
     private static final String PASS = "TEST PASSED";
     private static final String FAIL = "TEST FAILED";

--- a/src/main/java/org/fcrepo/spec/testsuite/report/HtmlReporter.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/report/HtmlReporter.java
@@ -1,6 +1,3 @@
-/**
- * @author Jorge Abrego, Fernando Cardoza
- */
 /*
  * Licensed to DuraSpace under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
@@ -45,6 +42,10 @@ import org.testng.ITestContext;
 import org.testng.ITestResult;
 import org.testng.xml.XmlSuite;
 
+/**
+ *
+ * @author Jorge Abrego, Fernando Cardoza
+ */
 public class HtmlReporter implements IReporter {
 
     HashMap<String, Integer> passClasses;

--- a/src/main/java/org/fcrepo/spec/testsuite/test/Container.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/test/Container.java
@@ -1,6 +1,3 @@
-/**
- * @author Jorge Abrego, Fernando Cardoza
- */
 /*
  * Licensed to DuraSpace under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
@@ -34,7 +31,10 @@ import org.testng.Assert;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
-
+/**
+ *
+ * @author Jorge Abrego, Fernando Cardoza
+ */
 public class Container {
     public static String body = "@prefix ldp: <http://www.w3.org/ns/ldp#> ."
                                 + "@prefix dcterms: <http://purl.org/dc/terms/> ."

--- a/src/main/java/org/fcrepo/spec/testsuite/test/ExternalBinaryContent.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/test/ExternalBinaryContent.java
@@ -1,6 +1,3 @@
-/**
- * @author Jorge Abrego, Fernando Cardoza
- */
 /*
  * Licensed to DuraSpace under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
@@ -42,6 +39,10 @@ import org.testng.SkipException;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
+/**
+ *
+ * @author Jorge Abrego, Fernando Cardoza
+ */
 public class ExternalBinaryContent {
     public static String body = "@prefix ldp: <http://www.w3.org/ns/ldp#> ."
                                 + "@prefix dcterms: <http://purl.org/dc/terms/> ."

--- a/src/main/java/org/fcrepo/spec/testsuite/test/HttpDelete.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/test/HttpDelete.java
@@ -1,6 +1,3 @@
-/**
- * @author Jorge Abrego, Fernando Cardoza
- */
 /*
  * Licensed to DuraSpace under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
@@ -34,6 +31,10 @@ import org.testng.Assert;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
+/**
+ *
+ * @author Jorge Abrego, Fernando Cardoza
+ */
 public class HttpDelete {
     public static String body = "@prefix ldp: <http://www.w3.org/ns/ldp#> ."
                                 + "@prefix dcterms: <http://purl.org/dc/terms/> ."

--- a/src/main/java/org/fcrepo/spec/testsuite/test/HttpGet.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/test/HttpGet.java
@@ -1,6 +1,3 @@
-/**
- * @author Jorge Abrego, Fernando Cardoza
- */
 /*
  * Licensed to DuraSpace under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
@@ -36,6 +33,10 @@ import org.testng.Assert;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
+/**
+ *
+ * @author Jorge Abrego, Fernando Cardoza
+ */
 public class HttpGet {
     public static String body = "@prefix ldp: <http://www.w3.org/ns/ldp#> ."
                                 + "@prefix dcterms: <http://purl.org/dc/terms/> ."

--- a/src/main/java/org/fcrepo/spec/testsuite/test/HttpHead.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/test/HttpHead.java
@@ -1,6 +1,3 @@
-/**
- * @author Jorge Abrego, Fernando Cardoza
- */
 /*
  * Licensed to DuraSpace under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
@@ -38,6 +35,10 @@ import org.testng.Assert;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
+/**
+ *
+ * @author Jorge Abrego, Fernando Cardoza
+ */
 public class HttpHead {
     public static String body = "@prefix ldp: <http://www.w3.org/ns/ldp#> ."
                                 + "@prefix dcterms: <http://purl.org/dc/terms/> ."

--- a/src/main/java/org/fcrepo/spec/testsuite/test/HttpOptions.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/test/HttpOptions.java
@@ -1,6 +1,3 @@
-/**
- * @author Jorge Abrego, Fernando Cardoza
- */
 /*
  * Licensed to DuraSpace under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
@@ -32,6 +29,10 @@ import io.restassured.config.LogConfig;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
+/**
+ *
+ * @author Jorge Abrego, Fernando Cardoza
+ */
 public class HttpOptions {
     public String username;
     public String password;

--- a/src/main/java/org/fcrepo/spec/testsuite/test/HttpPatch.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/test/HttpPatch.java
@@ -1,6 +1,3 @@
-/**
- * @author Jorge Abrego, Fernando Cardoza
- */
 /*
  * Licensed to DuraSpace under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
@@ -38,6 +35,10 @@ import io.restassured.response.Response;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
+/**
+ *
+ * @author Jorge Abrego, Fernando Cardoza
+ */
 public class HttpPatch {
     public static String body2 = "@prefix ldp: <http://www.w3.org/ns/ldp#> ."
                                  + "@prefix dcterms: <http://purl.org/dc/terms/> ."

--- a/src/main/java/org/fcrepo/spec/testsuite/test/HttpPost.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/test/HttpPost.java
@@ -1,6 +1,3 @@
-/**
- * @author Jorge Abrego, Fernando Cardoza
- */
 /*
  * Licensed to DuraSpace under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
@@ -32,7 +29,10 @@ import io.restassured.config.LogConfig;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
-
+/**
+ *
+ * @author Jorge Abrego, Fernando Cardoza
+ */
 public class HttpPost {
     public static String body = "@prefix ldp: <http://www.w3.org/ns/ldp#> ."
                                 + "@prefix dcterms: <http://purl.org/dc/terms/> ."

--- a/src/main/java/org/fcrepo/spec/testsuite/test/HttpPut.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/test/HttpPut.java
@@ -1,6 +1,3 @@
-/**
- * @author Jorge Abrego, Fernando Cardoza
- */
 /*
  * Licensed to DuraSpace under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
@@ -33,6 +30,10 @@ import io.restassured.response.Response;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
+/**
+ *
+ * @author Jorge Abrego, Fernando Cardoza
+ */
 public class HttpPut {
     public static String body = "@prefix ldp: <http://www.w3.org/ns/ldp#> ."
                                 + "@prefix dcterms: <http://purl.org/dc/terms/> ."

--- a/src/main/java/org/fcrepo/spec/testsuite/test/Ldpnr.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/test/Ldpnr.java
@@ -1,6 +1,3 @@
-/**
- * @author Jorge Abrego, Fernando Cardoza
- */
 /*
  * Licensed to DuraSpace under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
@@ -33,6 +30,10 @@ import org.testng.Assert;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
+/**
+ *
+ * @author Jorge Abrego, Fernando Cardoza
+ */
 public class Ldpnr {
     public static String body = "@prefix ldp: <http://www.w3.org/ns/ldp#> ."
                                 + "@prefix dcterms: <http://purl.org/dc/terms/> ."

--- a/src/main/java/org/fcrepo/spec/testsuite/test/SetUpSuite.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/test/SetUpSuite.java
@@ -1,6 +1,3 @@
-/**
- * @author Fernando Cardoza
- */
 /*
  * Licensed to DuraSpace under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
@@ -25,6 +22,10 @@ import java.io.FileNotFoundException;
 import org.fcrepo.spec.testsuite.TestSuiteGlobals;
 import org.testng.annotations.BeforeSuite;
 
+/**
+ *
+ * @author Jorge Abrego, Fernando Cardoza
+ */
 public class SetUpSuite {
 
     /**


### PR DESCRIPTION
Basic housekeeping.  No functional changes.