### PR TITLE
Ensures that test class and method name are written to the  testing log.

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/TestInfo.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/TestInfo.java
@@ -31,7 +31,7 @@ public class TestInfo {
     private final static Map<String, TestInfo> TEST_INFO = new HashMap<>();
 
     private String id;
-    private String className;
+    private Class testClass;
     private String title;
     private String description;
     private String specLink;
@@ -40,15 +40,15 @@ public class TestInfo {
      * Default constructor
      *
      * @param id
-     * @param className
+     * @param testClass
      * @param title
      * @param description
      * @param specLink
      */
-    public TestInfo(final String id, final String className, final String title, final String description,
+    public TestInfo(final String id, final Class testClass, final String title, final String description,
                     final String specLink) {
         this.id = id;
-        this.className = className;
+        this.testClass = testClass;
         this.title = title;
         this.description = description;
         this.specLink = specLink;
@@ -76,10 +76,10 @@ public class TestInfo {
     }
 
     /**
-     * @return className
+     * @return testClass
      */
-    public String getClassName() {
-        return className;
+    public Class getTestClass() {
+        return testClass;
     }
 
     /**

--- a/src/main/java/org/fcrepo/spec/testsuite/TestSuiteGlobals.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/TestSuiteGlobals.java
@@ -187,7 +187,7 @@ public abstract class TestSuiteGlobals {
     }
 
     private static String formatTestLinkText(final TestInfo info) {
-        return info.getId() + ": " + info.getClassName() + " - " + info.getTitle();
+        return info.getId() + ": " + info.getTestClass().getName() + "." + info.getTitle() + "()";
     }
 
     /**

--- a/src/main/java/org/fcrepo/spec/testsuite/TestSuiteGlobals.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/TestSuiteGlobals.java
@@ -187,7 +187,7 @@ public abstract class TestSuiteGlobals {
     }
 
     private static String formatTestLinkText(final TestInfo info) {
-        return info.getId() + ": " + info.getTestClass().getName() + "." + info.getTitle() + "()";
+        return info.getId();
     }
 
     /**

--- a/src/main/java/org/fcrepo/spec/testsuite/report/HtmlReporter.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/report/HtmlReporter.java
@@ -178,10 +178,10 @@ public class HtmlReporter implements IReporter {
         throws IOException, NoSuchMethodException, IllegalAccessException,
         InstantiationException, InvocationTargetException {
         html.table(class_("indented"));
-        html.tr().th().content("Test");
+        html.tr().th().content("Specification Section");
         html.th().content("Req Level");
         html.th().content("Result");
-        html.th().content("")._tr();
+        html.th().content("Test Description")._tr();
         final Map<String, String[]> results = TestSuiteGlobals.orderTestsResults(passed, skipped, failed);
 
         for (String[] r : results.values()) {

--- a/src/main/java/org/fcrepo/spec/testsuite/test/AbstractTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/test/AbstractTest.java
@@ -27,6 +27,8 @@ import io.restassured.config.LogConfig;
 import io.restassured.response.Response;
 import org.fcrepo.spec.testsuite.TestInfo;
 import org.fcrepo.spec.testsuite.TestSuiteGlobals;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 
 /**
  * A test base class for common test functions.
@@ -35,19 +37,43 @@ import org.fcrepo.spec.testsuite.TestSuiteGlobals;
  */
 public class AbstractTest {
 
-    protected final PrintStream ps = TestSuiteGlobals.logFile();
+    protected PrintStream ps;
 
     protected String username;
     protected String password;
 
     /**
      * Constructor
+     *
      * @param username username
      * @param password password
      */
     public AbstractTest(final String username, final String password) {
         this.username = username;
         this.password = password;
+    }
+
+    /**
+     * setup
+     */
+    @BeforeMethod
+    public void setup() {
+        ps = TestSuiteGlobals.logFile();
+        ps.append("************************************************\n");
+        ps.append("**** Test Start ********************************\n");
+        ps.append("************************************************\n");
+
+    }
+
+    /**
+     * tearDown
+     */
+    @AfterMethod
+    public void tearDown() {
+        ps.append("\n************************************************");
+        ps.append("\n**** Test End **********************************");
+        ps.append("\n************************************************\n\n\n\n").close();
+
     }
 
     /**
@@ -61,7 +87,7 @@ public class AbstractTest {
      */
     protected TestInfo createTestInfo(final String id, final String title, final String description,
                                       final String specLink) {
-        return new TestInfo(id, getClass().getSimpleName(), title, description, specLink);
+        return new TestInfo(id, getClass(), title, description, specLink);
     }
 
     /**
@@ -77,7 +103,9 @@ public class AbstractTest {
     protected TestInfo setupTest(final String id, final String title, final String description, final String specLink,
                                  final PrintStream ps) {
         final TestInfo info = createTestInfo(id, title, description, specLink);
-        ps.append("\n" + info.getDescription()).append("\n");
+        ps.append("Class: " + info.getTestClass().getName()).append("\n");
+        ps.append("Method: " + info.getTitle()).append("\n");
+        ps.append("Description: " + info.getDescription()).append("\n");
         ps.append("Request:\n");
         return info;
     }

--- a/src/main/java/org/fcrepo/spec/testsuite/test/Container.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/test/Container.java
@@ -77,7 +77,7 @@ public class Container extends AbstractTest {
         createBasicContainer(uri, info).then()
                                        .log().all()
                                        .statusCode(201);
-        ps.append("\n -Case End- \n").close();
+
     }
 
     /**
@@ -127,7 +127,6 @@ public class Container extends AbstractTest {
         }
         final String body = resP.getBody().asString();
         ps.append(body);
-        ps.append("\n -Case End- \n").close();
 
         final boolean triple = TestSuiteGlobals.checkMembershipTriple(body);
 
@@ -207,7 +206,6 @@ public class Container extends AbstractTest {
         }
         final String body = resP.getBody().asString();
         ps.append(body);
-        ps.append("\n -Case End- \n").close();
 
         if (body.contains("hasMemberRelation") && body.contains("membershipResource") &&
             !body.contains("ldp:contains")) {
@@ -263,7 +261,6 @@ public class Container extends AbstractTest {
         }
         final String body = resP.getBody().asString();
         ps.append(body);
-        ps.append("\n -Case End- \n").close();
 
         final boolean triple = TestSuiteGlobals.checkMembershipTriple(body);
 

--- a/src/main/java/org/fcrepo/spec/testsuite/test/ExternalBinaryContent.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/test/ExternalBinaryContent.java
@@ -86,7 +86,6 @@ public class ExternalBinaryContent extends AbstractTest {
                    .log().all()
                    .statusCode(201);
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -122,7 +121,6 @@ public class ExternalBinaryContent extends AbstractTest {
                    .log().all()
                    .statusCode(201);
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -177,7 +175,6 @@ public class ExternalBinaryContent extends AbstractTest {
                    .log().all()
                    .statusCode(204);
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -206,7 +203,6 @@ public class ExternalBinaryContent extends AbstractTest {
                    .log().all()
                    .statusCode(200).header("Accept-Post", containsString("access-type=URL"));
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -241,7 +237,6 @@ public class ExternalBinaryContent extends AbstractTest {
                    .log().all()
                    .statusCode(415);
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -276,7 +271,6 @@ public class ExternalBinaryContent extends AbstractTest {
                    .log().all()
                    .statusCode(415);
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -319,7 +313,6 @@ public class ExternalBinaryContent extends AbstractTest {
             ps.append(h.getName() + ": ");
             ps.append(h.getValue() + "\n");
         }
-        ps.append("\n -Case End- \n").close();
 
         final String status = String.valueOf(res.getStatusCode());
         final char charStatus = status.charAt(0);
@@ -411,7 +404,6 @@ public class ExternalBinaryContent extends AbstractTest {
             Assert.assertTrue(false, "FAIL");
         }
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -519,7 +511,6 @@ public class ExternalBinaryContent extends AbstractTest {
             Assert.assertTrue(false, "FAIL");
         }
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -581,14 +572,13 @@ public class ExternalBinaryContent extends AbstractTest {
 
             if (!isValid) {
                 ps.append("Content-Location header was not sent in the response.");
-                ps.append("\n -Case End- \n").close();
+
                 throw new AssertionError("Content-Location header was not set in the response.");
             }
         } else {
             throw new SkipException("Skipping this exception");
         }
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -651,14 +641,13 @@ public class ExternalBinaryContent extends AbstractTest {
 
             if (!isValid) {
                 ps.append("Content-Location header was not sent in the response.");
-                ps.append("\n -Case End- \n").close();
+
                 throw new AssertionError("Content-Location header was not set in the response.");
             }
         } else {
             throw new SkipException("Skipping this exception");
         }
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -705,7 +694,6 @@ public class ExternalBinaryContent extends AbstractTest {
                    .log().all()
                    .statusCode(200).header("Digest", containsString("md5"));
 
-        ps.append("-Case End- \n").close();
     }
 
     /**
@@ -752,7 +740,6 @@ public class ExternalBinaryContent extends AbstractTest {
                    .log().all()
                    .statusCode(200).header("Digest", containsString("md5"));
 
-        ps.append("-Case End- \n").close();
     }
 
     /**
@@ -808,7 +795,6 @@ public class ExternalBinaryContent extends AbstractTest {
         Assert.assertTrue(headers.getValue("Digest").contains("md5") ||
                           headers.getValue("Digest").contains("sha"), "OK");
 
-        ps.append("-Case End- \n").close();
     }
 
     /**
@@ -865,7 +851,6 @@ public class ExternalBinaryContent extends AbstractTest {
         Assert.assertTrue(headers.getValue("Digest").contains("md5") ||
                           headers.getValue("Digest").contains("sha"), "OK");
 
-        ps.append("-Case End- \n").close();
     }
 
     /**
@@ -926,7 +911,6 @@ public class ExternalBinaryContent extends AbstractTest {
         Assert.assertTrue(headers.getValue("Digest").contains("md5") ||
                           headers.getValue("Digest").contains("sha"), "OK");
 
-        ps.append("-Case End- \n").close();
     }
 
     /**
@@ -986,7 +970,6 @@ public class ExternalBinaryContent extends AbstractTest {
         Assert.assertTrue(headers.getValue("Digest").contains("md5") ||
                           headers.getValue("Digest").contains("sha"), "OK");
 
-        ps.append("-Case End- \n").close();
     }
 
     /**
@@ -1035,7 +1018,6 @@ public class ExternalBinaryContent extends AbstractTest {
                    .log().all()
                    .statusCode(200).header("Digest", containsString("md5"));
 
-        ps.append("-Case End- \n").close();
     }
 
     /**
@@ -1085,6 +1067,5 @@ public class ExternalBinaryContent extends AbstractTest {
                    .log().all()
                    .statusCode(200).header("Digest", containsString("md5"));
 
-        ps.append("-Case End- \n").close();
     }
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/test/HttpDelete.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/test/HttpDelete.java
@@ -172,7 +172,6 @@ public class HttpDelete extends AbstractTest {
 
         }
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**

--- a/src/main/java/org/fcrepo/spec/testsuite/test/HttpGet.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/test/HttpGet.java
@@ -84,7 +84,6 @@ public class HttpGet extends AbstractTest {
                                            containsString(
                                                "http://fedora.info/definitions/fcrepo#PreferInboundReferences"));
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -115,7 +114,6 @@ public class HttpGet extends AbstractTest {
                    .log().all()
                    .statusCode(200).header("preference-applied", containsString("return=minimal"));
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -155,7 +153,6 @@ public class HttpGet extends AbstractTest {
                    .log().all()
                    .statusCode(200).header("Link", containsString("describes"));
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -195,7 +192,6 @@ public class HttpGet extends AbstractTest {
                    .log().all()
                    .statusCode(200).header("Digest", containsString("md5"));
 
-        ps.append("-Case End- \n").close();
     }
 
     /**
@@ -243,7 +239,6 @@ public class HttpGet extends AbstractTest {
         Assert
             .assertTrue(headers.getValue("Digest").contains("md5") || headers.getValue("Digest").contains("sha"), "OK");
 
-        ps.append("-Case End- \n").close();
     }
 
     /**
@@ -292,7 +287,6 @@ public class HttpGet extends AbstractTest {
         Assert
             .assertTrue(headers.getValue("Digest").contains("md5") || headers.getValue("Digest").contains("sha"), "OK");
 
-        ps.append("-Case End- \n").close();
     }
 
     /**
@@ -331,7 +325,6 @@ public class HttpGet extends AbstractTest {
                    .log().all()
                    .statusCode(200).header("Digest", containsString("md5"));
 
-        ps.append("-Case End- \n").close();
     }
 
     /**
@@ -371,7 +364,6 @@ public class HttpGet extends AbstractTest {
                    .log().all()
                    .statusCode(200).header("Digest", containsString("md5"));
 
-        ps.append("-Case End- \n").close();
     }
 
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/test/HttpHead.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/test/HttpHead.java
@@ -77,7 +77,6 @@ public class HttpHead extends AbstractTest {
                    .log().all()
                    .statusCode(200).assertThat().body(equalTo(""));
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -134,8 +133,6 @@ public class HttpHead extends AbstractTest {
             ps.append(h.getName().toString() + ": ");
             ps.append(h.getValue().toString() + "\n");
         }
-
-        ps.append("\n -Case End- \n").close();
 
         if (resget.getStatusCode() == 200 && reshead.getStatusCode() == 200) {
 
@@ -220,7 +217,7 @@ public class HttpHead extends AbstractTest {
         } else {
             Assert.assertTrue(false, "FAIL");
         }
-        ps.append("\n -Case End- \n").close();
+
     }
 
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/test/HttpOptions.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/test/HttpOptions.java
@@ -66,7 +66,6 @@ public class HttpOptions extends AbstractTest {
                    .log().all()
                    .statusCode(200);
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -95,6 +94,5 @@ public class HttpOptions extends AbstractTest {
                    .log().all()
                    .statusCode(200).header("Allow", containsString("GET"));
 
-        ps.append("\n -Case End- \n").close();
     }
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/test/HttpPatch.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/test/HttpPatch.java
@@ -117,7 +117,6 @@ public class HttpPatch extends AbstractTest {
                    .log().all()
                    .statusCode(204);
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -148,7 +147,6 @@ public class HttpPatch extends AbstractTest {
                    .log().all()
                    .statusCode(204);
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -183,7 +181,6 @@ public class HttpPatch extends AbstractTest {
                    .log().all()
                    .statusCode(409);
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -217,7 +214,6 @@ public class HttpPatch extends AbstractTest {
                    .log().all()
                    .statusCode(409).body(containsString("lastModified"));
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -252,7 +248,6 @@ public class HttpPatch extends AbstractTest {
                    .log().all()
                    .statusCode(409).header("Link", containsString("constrainedBy"));
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -308,11 +303,10 @@ public class HttpPatch extends AbstractTest {
 
         ps.append(str);
         if (err) {
-            ps.append("\n -Case End- \n").close();
+
             throw new AssertionError("\nThe response status code is not a valid successful status code for PATCH.");
         }
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -357,7 +351,6 @@ public class HttpPatch extends AbstractTest {
                    .log().all()
                    .statusCode(409);
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -392,6 +385,5 @@ public class HttpPatch extends AbstractTest {
                    .log().all()
                    .statusCode(409);
 
-        ps.append("\n -Case End- \n").close();
     }
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/test/HttpPost.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/test/HttpPost.java
@@ -64,7 +64,7 @@ public class HttpPost extends AbstractTest {
             .then()
             .log().all()
             .statusCode(201);
-        ps.append("\n -Case End- \n").close();
+
     }
 
     /**
@@ -87,7 +87,7 @@ public class HttpPost extends AbstractTest {
         createBasicContainer(uri, info).then()
                                        .log().all()
                                        .statusCode(201).header("Link", containsString("constrainedBy"));
-        ps.append("\n -Case End- \n").close();
+
     }
 
     /**
@@ -114,7 +114,7 @@ public class HttpPost extends AbstractTest {
                    .then()
                    .log().all()
                    .statusCode(201);
-        ps.append("\n -Case End- \n").close();
+
     }
 
     /**
@@ -143,7 +143,6 @@ public class HttpPost extends AbstractTest {
                    .log().all()
                    .statusCode(201).header("Link", containsString("describedby"));
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -178,7 +177,6 @@ public class HttpPost extends AbstractTest {
                    .log().all()
                    .statusCode(409);
 
-        ps.append("-Case End- \n").close();
     }
 
     /**
@@ -210,6 +208,5 @@ public class HttpPost extends AbstractTest {
                    .log().all()
                    .statusCode(400);
 
-        ps.append("\n -Case End- \n").close();
     }
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/test/HttpPut.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/test/HttpPut.java
@@ -86,7 +86,6 @@ public class HttpPut extends AbstractTest {
                    .log().all()
                    .statusCode(409);
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -126,7 +125,6 @@ public class HttpPut extends AbstractTest {
                    .log().all()
                    .statusCode(204);
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -180,7 +178,6 @@ public class HttpPut extends AbstractTest {
                    .log().all()
                    .statusCode(409);
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -229,7 +226,6 @@ public class HttpPut extends AbstractTest {
                    .log().all()
                    .statusCode(409).body(containsString("ldp#contains"));
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -275,7 +271,6 @@ public class HttpPut extends AbstractTest {
                    .log().all()
                    .statusCode(409).header("Link", containsString("constrainedBy"));
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -309,7 +304,6 @@ public class HttpPut extends AbstractTest {
                    .log().all()
                    .statusCode(204);
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -350,7 +344,6 @@ public class HttpPut extends AbstractTest {
                    .log().all()
                    .statusCode(409);
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -388,7 +381,6 @@ public class HttpPut extends AbstractTest {
                    .log().all()
                    .statusCode(400);
 
-        ps.append("\n -Case End- \n").close();
     }
 
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/test/Ldpnr.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/test/Ldpnr.java
@@ -110,17 +110,16 @@ public class Ldpnr extends AbstractTest {
                 Assert.assertTrue(true, "OK");
             } else {
                 ps.append("\nExpected a Link: rel=\"type\" http://www.w3.org/ns/ldp#NonRDFSource.\n");
-                ps.append("\n -Case End- \n").close();
+
                 throw new AssertionError("Expected a Link: rel=\"type\" http://www.w3.org/ns/ldp#NonRDFSource.");
             }
 
         } else {
             ps.append("\nExpected response with a 2xx range status code.\n");
-            ps.append("\n -Case End- \n").close();
+
             throw new AssertionError("Expected response with a 2xx range status code.");
         }
 
-        ps.append("\n -Case End- \n").close();
     }
 
     /**
@@ -165,10 +164,9 @@ public class Ldpnr extends AbstractTest {
 
         if (res.getStatusCode() >= 200 && res.getStatusCode() < 300) {
             ps.append("\nExpected response with a 4xx range status code.\n");
-            ps.append("\n -Case End- \n").close();
+
             throw new AssertionError("Expected response with a 4xx range status code.");
         }
 
-        ps.append("\n -Case End- \n").close();
     }
 }


### PR DESCRIPTION
Also fixes a related bug (output log missing after testsuite completes),
improves the layout of the testing log, and removes related cruft.
Resolves https://github.com/fcrepo4-labs/Fedora-API-Test-Suite/issues/66