### PR TITLE
Test 3.1.1: Add simple test for containment

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/Constants.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/Constants.java
@@ -31,6 +31,14 @@ public class Constants {
                                                       "dcterms:description 'This is a crud container for the Fedora " +
                                                       "API Test Suite.' . ";
 
+    public static final String DIRECT_CONTAINER_BODY = "@prefix ldp: <http://www.w3.org/ns/ldp#> ."
+            + "@prefix dcterms: <http://purl.org/dc/terms/> ."
+            + "<> dcterms:title 'A Direct Container' ; "
+            + "dcterms:description 'This is a direct container for the Fedora ' ;"
+            + "ldp:membershipResource <%membershipResource%> ;"
+            + "ldp:hasMemberRelation dcterms:hasPart ." ;
+
+
     public static final String CONTENT_DISPOSITION = "Content-Disposition";
     public static final String SLUG = "slug";
     public static final String DIGEST = "Digest";


### PR DESCRIPTION
This is the first of three tests for section 3.1.1

The other two tests will be:
- 3.1.1-C: test for membership
- 3.1.1-D: test for separation of containment/membership

Related to: https://github.com/fcrepo4-labs/Fedora-API-Test-Suite/issues/95