### PR TITLE
Test 3.1.1-C & Test 3.1.1-D : Add tests for containment/membership

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
@@ -138,16 +138,20 @@ public class AbstractTest {
     }
 
     protected Response createDirectContainer(final String uri, final String body) {
-        final Response response = createRequestAuthOnly()
+        final Response response = createDirectContainerUnverifed(uri, body);
+
+        Assert.assertEquals(response.getStatusCode(), 201);
+
+        return response;
+    }
+
+    protected Response createDirectContainerUnverifed(final String uri, final String body) {
+        return createRequestAuthOnly()
                 .header("Link", "<http://www.w3.org/ns/ldp#DirectContainer>; rel=\"type\"")
                 .header("Content-Type", "text/turtle")
                 .body(body)
                 .when()
                 .post(uri);
-
-        Assert.assertEquals(response.getStatusCode(), 201);
-
-        return response;
     }
 
     protected RequestSpecification createRequest() {

--- a/src/main/java/org/fcrepo/spec/testsuite/Constants.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/Constants.java
@@ -38,6 +38,12 @@ public class Constants {
             + "ldp:membershipResource <%membershipResource%> ;"
             + "ldp:hasMemberRelation dcterms:hasPart ." ;
 
+    public static String RDF_BODY = "@prefix dc: <http://purl.org/dc/terms/> . "
+            + "@prefix foaf: <http://xmlns.com/foaf/0.1/> . "
+            + "<> a foaf:Person; "
+            + "foaf:name \"Pythagoras\" ; "
+            + "foaf:based_near \"Croton\" ; "
+            + "foaf:interest [ dc:title \"Geometry\" ] .";
 
     public static final String CONTENT_DISPOSITION = "Content-Disposition";
     public static final String SLUG = "slug";

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/HttpGet.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/HttpGet.java
@@ -19,6 +19,7 @@ package org.fcrepo.spec.testsuite.crud;
 
 import static org.fcrepo.spec.testsuite.Constants.CONTENT_DISPOSITION;
 import static org.fcrepo.spec.testsuite.Constants.DIGEST;
+import static org.fcrepo.spec.testsuite.Constants.RDF_BODY;
 import static org.fcrepo.spec.testsuite.Constants.SLUG;
 import static org.hamcrest.Matchers.containsString;
 
@@ -114,7 +115,7 @@ public class HttpGet extends AbstractTest {
         final Response resource = createBasicContainer(uri, info);
         final String locationHeader = getLocation(resource);
 
-        final Response child = createBasicContainer(locationHeader, "child", Container.personBody);
+        final Response child = createBasicContainer(locationHeader, "child", RDF_BODY);
 
         // Triple expected in result body
         final Statement triple = ResourceFactory.createStatement(


### PR DESCRIPTION
- Add test to verify 409 or separation of membership and containment
- Add test to verify PreferMinimalContainer
- Move static RDF body to Constants.java
- Remove unused "pythagoras" and "portrait" RDF bodies

With https://github.com/fcrepo4-labs/Fedora-API-Test-Suite/pull/108,
...Resolves: https://github.com/fcrepo4-labs/Fedora-API-Test-Suite/issues/95