### PR TITLE
Non-Functional clean-up of code cruft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ target/
 maven-eclipse.xml
 atlassian-ide-plugin.xml
 test-output
+testng-local.xml
 /bin
 /report

--- a/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
@@ -46,8 +46,8 @@ public class AbstractTest {
 
     protected PrintStream ps;
 
-    protected String username;
-    protected String password;
+    protected final String username;
+    protected final String password;
 
     /**
      * Constructor
@@ -85,34 +85,27 @@ public class AbstractTest {
 
     /**
      * A convenience method for creating TestInfo instances.
-     *
-     * @param id
-     * @param title
-     * @param description
-     * @param specLink
-     * @return
      */
-    protected TestInfo createTestInfo(final String id, final String title, final String description,
-                                      final String specLink) {
+    private TestInfo createTestInfo(final String id, final String title, final String description,
+                                    final String specLink) {
         return new TestInfo(id, getClass(), title, description, specLink);
     }
 
     /**
      * A convenience method for setup boilerplate
-     *
-     * @param id
-     * @param title
-     * @param description
-     * @param specLink
-     * @param ps
-     * @return
      */
     protected TestInfo setupTest(final String id, final String title, final String description, final String specLink,
                                  final PrintStream ps) {
         final TestInfo info = createTestInfo(id, title, description, specLink);
-        ps.append("Class: " + info.getTestClass().getName()).append("\n");
-        ps.append("Method: " + info.getTitle()).append("\n");
-        ps.append("Description: " + info.getDescription()).append("\n");
+        ps.append("Class: ");
+        ps.append(info.getTestClass().getName());
+        ps.append("\n");
+        ps.append("Method: ");
+        ps.append(info.getTitle());
+        ps.append("\n");
+        ps.append("Description: ");
+        ps.append(info.getDescription());
+        ps.append("\n");
         ps.append("Request:\n");
         return info;
     }
@@ -159,11 +152,11 @@ public class AbstractTest {
                                       .log().all();
     }
 
-    protected RequestSpecification createRequest(final String slug, final String contentType) {
+    private RequestSpecification createRequest(final String slug, final String contentType) {
         return createRequest().header(SLUG, slug).contentType(contentType);
     }
 
-    protected RequestSpecification createRequestAuthOnly() {
+    private RequestSpecification createRequestAuthOnly() {
         return RestAssured.given()
                           .auth().basic(this.username, this.password);
     }

--- a/src/main/java/org/fcrepo/spec/testsuite/Constants.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/Constants.java
@@ -38,7 +38,7 @@ public class Constants {
             + "ldp:membershipResource <%membershipResource%> ;"
             + "ldp:hasMemberRelation dcterms:hasPart ." ;
 
-    public static String RDF_BODY = "@prefix dc: <http://purl.org/dc/terms/> . "
+    public static final String RDF_BODY = "@prefix dc: <http://purl.org/dc/terms/> . "
             + "@prefix foaf: <http://xmlns.com/foaf/0.1/> . "
             + "<> a foaf:Person; "
             + "foaf:name \"Pythagoras\" ; "

--- a/src/main/java/org/fcrepo/spec/testsuite/SetUpSuite.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/SetUpSuite.java
@@ -17,8 +17,6 @@
  */
 package org.fcrepo.spec.testsuite;
 
-import java.io.FileNotFoundException;
-
 import org.testng.annotations.BeforeSuite;
 
 /**
@@ -26,11 +24,12 @@ import org.testng.annotations.BeforeSuite;
  */
 public class SetUpSuite {
 
+
     /**
-     * @throws FileNotFoundException
+     * Reset Globals
      */
     @BeforeSuite
-    public void setUp() throws FileNotFoundException {
+    public void setUp() {
         TestSuiteGlobals.resetFile();
     }
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/TestInfo.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/TestInfo.java
@@ -30,11 +30,11 @@ public class TestInfo {
 
     private final static Map<String, TestInfo> TEST_INFO = new HashMap<>();
 
-    private String id;
-    private Class testClass;
-    private String title;
-    private String description;
-    private String specLink;
+    private final String id;
+    private final Class testClass;
+    private final String title;
+    private final String description;
+    private final String specLink;
 
     /**
      * Default constructor

--- a/src/main/java/org/fcrepo/spec/testsuite/TestSuiteGlobals.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/TestSuiteGlobals.java
@@ -21,10 +21,8 @@ import static org.fcrepo.spec.testsuite.Constants.BASIC_CONTAINER_LINK_HEADER;
 import static org.fcrepo.spec.testsuite.Constants.SLUG;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
-import java.lang.reflect.InvocationTargetException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Map;
@@ -41,15 +39,14 @@ import org.testng.internal.Utils;
  * @author Jorge Abrego, Fernando Cardoza
  */
 public abstract class TestSuiteGlobals {
-    public static String cssReport = "reportStyle.css";
-    public static String outputDirectory = "report";
-    public static String outputName = "testsuite";
-    public static String earlReportSyntax = "TURTLE";
-    public static String ldptNamespace = "http://fedora.info/2017/06/30/spec/#";
-    public static String earlReportAssertor = "https://wiki.duraspace.org/display/FF";
-    public static String resourcePointer;
-    public static String[] payloadHeaders = {"Content-Length", "Content-Range", "Trailer", "Transfer-Encoding"};
-    public static String[] membershipTriples = {"hasMemberRelation", "isMemberOfRelation", "membershipResource",
+    public static final String cssReport = "reportStyle.css";
+    public static final String outputDirectory = "report";
+    public static final String outputName = "testsuite";
+    public static final String earlReportSyntax = "TURTLE";
+    public static final String ldptNamespace = "http://fedora.info/2017/06/30/spec/#";
+    public static final String earlReportAssertor = "https://wiki.duraspace.org/display/FF";
+    private static final String[] payloadHeaders = {"Content-Length", "Content-Range", "Trailer", "Transfer-Encoding"};
+    private static final String[] membershipTriples = {"hasMemberRelation", "isMemberOfRelation", "membershipResource",
                                                 "insertedContentRelation"};
 
     /**
@@ -109,24 +106,14 @@ public abstract class TestSuiteGlobals {
     /**
      * @return date
      */
-    public static String today() {
-        final String date = new SimpleDateFormat("MMddyyyyHHmmss").format(new Date());
-        return date;
+    private static String today() {
+        return new SimpleDateFormat("MMddyyyyHHmmss").format(new Date());
     }
 
     /**
-     * @param format
-     * @return date
+     * Remove existing log file
      */
-    public static String today(final String format) {
-        final String date = new SimpleDateFormat(format).format(new Date());
-        return date;
-    }
-
-    /**
-     * @throws FileNotFoundException
-     */
-    public static void resetFile() throws FileNotFoundException {
+    public static void resetFile() {
         final File dir = new File("report");
         dir.mkdirs();
         final File f = new File(
@@ -144,8 +131,7 @@ public abstract class TestSuiteGlobals {
             final FileOutputStream fos = new FileOutputStream(new File(TestSuiteGlobals.outputDirectory + "/" +
                                                                        TestSuiteGlobals.outputName + "-execution.log"),
                                                               true);
-            final PrintStream ps = new PrintStream(fos);
-            return ps;
+            return new PrintStream(fos);
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }
@@ -156,14 +142,9 @@ public abstract class TestSuiteGlobals {
      * @param skipped
      * @param failed
      * @return results
-     * @throws IllegalAccessException
-     * @throws InstantiationException
-     * @throws NoSuchMethodException
-     * @throws InvocationTargetException
      */
     public static Map<String, String[]> orderTestsResults(final IResultMap passed,
-                                                          final IResultMap skipped, final IResultMap failed)
-        throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
+                                                          final IResultMap skipped, final IResultMap failed) {
         final TreeMap<String, String[]> results = new TreeMap<>();
         addToResults(results, passed, "PASS");
         addToResults(results, skipped, "SKIPPED");
@@ -177,9 +158,9 @@ public abstract class TestSuiteGlobals {
             final ITestNGMethod method = result.getMethod();
             final TestInfo info = TestInfo.getByMethodName(method.getMethodName());
             final String[] details = new String[6];
-            details[0] = info.getSpecLink().toString();
+            details[0] = info.getSpecLink();
             details[1] = outcome;
-            details[2] = info.getDescription().toString();
+            details[2] = info.getDescription();
             details[3] = formatTestLinkText(info);
             details[4] = getStackTrace(result.getThrowable());
             details[5] = method.getGroups()[0];
@@ -195,7 +176,7 @@ public abstract class TestSuiteGlobals {
      * @param thrown
      * @return msg
      */
-    public static String getStackTrace(final Throwable thrown) {
+    private static String getStackTrace(final Throwable thrown) {
         String msg = "";
         if (thrown != null) {
             if (thrown.getClass().getName().contains("TEST SKIPPED")) {

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/Container.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/Container.java
@@ -17,7 +17,6 @@
  */
 package org.fcrepo.spec.testsuite.crud;
 
-import java.io.FileNotFoundException;
 import java.util.List;
 
 import io.restassured.http.Header;
@@ -57,7 +56,7 @@ public class Container extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void createLDPC(final String uri) throws FileNotFoundException {
+    public void createLDPC(final String uri) {
         final TestInfo info = setupTest("3.1.1-A", "createLDPC",
                                         "Implementations must support the creation and management of [LDP] Containers.",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpc", ps);
@@ -74,7 +73,7 @@ public class Container extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void ldpcContainmentTriples(final String uri) throws FileNotFoundException {
+    public void ldpcContainmentTriples(final String uri) {
         final TestInfo info = setupTest("3.1.1-B",
                                         "ldpcContainmentTriples",
                                         "LDP Containers must distinguish [containment triples]",
@@ -94,11 +93,11 @@ public class Container extends AbstractTest {
             .when()
             .get(getLocation(container));
 
-        ps.append(resP.getStatusLine().toString() + "\n");
+        ps.append(resP.getStatusLine()).append("\n");
         final Headers headers = resP.getHeaders();
         for (Header h : headers) {
-            ps.append(h.getName().toString() + ": ");
-            ps.append(h.getValue().toString() + "\n");
+            ps.append(h.getName()).append(": ");
+            ps.append(h.getValue()).append("\n");
         }
         final String body = resP.getBody().asString();
         ps.append(body);
@@ -127,7 +126,7 @@ public class Container extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void ldpcMembershipTriples(final String uri) throws FileNotFoundException {
+    public void ldpcMembershipTriples(final String uri) {
         final TestInfo info = setupTest("3.1.1-C", "ldpcMembershipTriples",
                                         "LDP Containers must distinguish [membership] triples.",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpc",
@@ -152,11 +151,11 @@ public class Container extends AbstractTest {
             // 1. Expect two ldp:contains triples for basic GET
             final Response resP = createRequest().when().get(getLocation(container));
 
-            ps.append(resP.getStatusLine().toString() + "\n");
+            ps.append(resP.getStatusLine()).append("\n");
             final Headers headers = resP.getHeaders();
             for (Header h : headers) {
-                ps.append(h.getName().toString() + ": ");
-                ps.append(h.getValue().toString() + "\n");
+                ps.append(h.getName()).append(": ");
+                ps.append(h.getValue()).append("\n");
             }
             final String body = resP.getBody().asString();
             ps.append(body);
@@ -228,7 +227,7 @@ public class Container extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void ldpcMinimalContainerTriples(final String uri) throws FileNotFoundException {
+    public void ldpcMinimalContainerTriples(final String uri) {
         final TestInfo info = setupTest("3.1.1-D", "ldpcMinimalContainerTriples",
                                         "LDP Containers must distinguish [minimal-container] triples.",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpc",
@@ -247,11 +246,11 @@ public class Container extends AbstractTest {
                 .when()
                 .get(getLocation(container));
 
-        ps.append(resP.getStatusLine().toString() + "\n");
+        ps.append(resP.getStatusLine()).append("\n");
         final Headers headers = resP.getHeaders();
         for (Header h : headers) {
-            ps.append(h.getName().toString() + ": ");
-            ps.append(h.getValue().toString() + "\n");
+            ps.append(h.getName()).append(": ");
+            ps.append(h.getValue()).append("\n");
         }
         final String body = resP.getBody().asString();
         ps.append(body);

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/ExternalBinaryContent.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/ExternalBinaryContent.java
@@ -22,11 +22,11 @@ import static org.fcrepo.spec.testsuite.Constants.DIGEST;
 import static org.fcrepo.spec.testsuite.Constants.SLUG;
 import static org.hamcrest.Matchers.containsString;
 
-import java.io.FileNotFoundException;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import io.restassured.RestAssured;
@@ -64,7 +64,7 @@ public class ExternalBinaryContent extends AbstractTest {
      */
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
-    public void postCreateExternalBinaryContent(final String uri) throws FileNotFoundException {
+    public void postCreateExternalBinaryContent(final String uri) {
         final TestInfo info = setupTest("3.9-A-1", "postCreateExternalBinaryContent",
                                         "Fedora servers should support the creation of LDP-NRs with Content-Type "
                                         + "of message/external-body and"
@@ -93,7 +93,7 @@ public class ExternalBinaryContent extends AbstractTest {
      */
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
-    public void putCreateExternalBinaryContent(final String uri) throws FileNotFoundException {
+    public void putCreateExternalBinaryContent(final String uri) {
         final TestInfo info = setupTest("3.9-A-2", "putCreateExternalBinaryContent",
                                         "Fedora servers should support the creation of LDP-NRs with Content-Type "
                                         + "of message/external-body and"
@@ -122,7 +122,7 @@ public class ExternalBinaryContent extends AbstractTest {
      */
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
-    public void putUpdateExternalBinaryContent(final String uri) throws FileNotFoundException {
+    public void putUpdateExternalBinaryContent(final String uri) {
         final TestInfo info = setupTest("3.9-A-3", "putUpdateExternalBinaryContent",
                                         "Fedora servers should support the creation of LDP-NRs with Content-Type "
                                         + "of message/external-body and"
@@ -166,7 +166,7 @@ public class ExternalBinaryContent extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void createExternalBinaryContentCheckAccesType(final String uri) throws FileNotFoundException {
+    public void createExternalBinaryContentCheckAccesType(final String uri) {
         final TestInfo info = setupTest("3.9-B", "createExternalBinaryContentCheckAccesType",
                                         "Fedora servers must advertise support in the Accept-Post response header for" +
                                         " each supported access-type "
@@ -190,7 +190,7 @@ public class ExternalBinaryContent extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void postCheckUnsupportedMediaType(final String uri) throws FileNotFoundException {
+    public void postCheckUnsupportedMediaType(final String uri) {
         final TestInfo info = setupTest("3.9-C-1", "postCheckUnsupportedMediaType",
                                         "Fedora servers receiving requests that would create or update a LDP-NR with "
                                         + "a message/external-body with an "
@@ -220,7 +220,7 @@ public class ExternalBinaryContent extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void putCheckUnsupportedMediaType(final String uri) throws FileNotFoundException {
+    public void putCheckUnsupportedMediaType(final String uri) {
         final TestInfo info = setupTest("3.9-C-2", "putCheckUnsupportedMediaType",
                                         "Fedora servers receiving requests that would create or update a LDP-NR with a "
                                         + "message/external-body with an "
@@ -250,7 +250,7 @@ public class ExternalBinaryContent extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void checkUnsupportedMediaType(final String uri) throws FileNotFoundException {
+    public void checkUnsupportedMediaType(final String uri) {
         final TestInfo info = setupTest("3.9-D", "checkUnsupportedMediaType",
                                         "In the case that a Fedora server does not support external LDP-NR content, "
                                         +
@@ -271,23 +271,19 @@ public class ExternalBinaryContent extends AbstractTest {
                                             .when()
                                             .post(uri);
 
-        ps.append(res.getStatusLine() + "\n");
+        ps.append(res.getStatusLine()).append("\n");
         final Headers headers = res.getHeaders();
         for (Header h : headers) {
-            ps.append(h.getName() + ": ");
-            ps.append(h.getValue() + "\n");
+            ps.append(h.getName()).append(": ");
+            ps.append(h.getValue()).append("\n");
         }
 
         final String status = String.valueOf(res.getStatusCode());
         final char charStatus = status.charAt(0);
         if (charStatus != '2') {
-            if (res.getStatusCode() == 415) {
-                Assert.assertTrue(true, "OK");
-            } else {
-                Assert.assertTrue(false, "FAIL");
+            if (res.getStatusCode() != 415) {
+                Assert.fail();
             }
-        } else {
-            Assert.assertTrue(true, "OK");
         }
     }
 
@@ -298,7 +294,7 @@ public class ExternalBinaryContent extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void postCheckHeaders(final String uri) throws FileNotFoundException {
+    public void postCheckHeaders(final String uri) {
         final TestInfo info = setupTest("3.9-E-1", "postCheckHeaders",
                                         "Fedora servers receiving requests that would create or update an LDP-NR with" +
                                         " Content-Type: "
@@ -315,11 +311,11 @@ public class ExternalBinaryContent extends AbstractTest {
                                                  .when()
                                                  .post(uri);
 
-        ps.append(resource.getStatusLine() + "\n");
+        ps.append(resource.getStatusLine()).append("\n");
         final Headers headers = resource.getHeaders();
         for (Header h : headers) {
-            ps.append(h.getName() + ": ");
-            ps.append(h.getValue() + "\n");
+            ps.append(h.getName()).append(": ");
+            ps.append(h.getValue()).append("\n");
         }
         final List<String> h1 = new ArrayList<>();
         for (Header h : headers) {
@@ -338,11 +334,11 @@ public class ExternalBinaryContent extends AbstractTest {
                                             .when()
                                             .post(uri);
 
-        ps.append(res.getStatusLine() + "\n");
+        ps.append(res.getStatusLine()).append("\n");
         final Headers headersext = res.getHeaders();
         for (Header h : headersext) {
-            ps.append(h.getName() + ": ");
-            ps.append(h.getValue() + "\n");
+            ps.append(h.getName()).append(": ");
+            ps.append(h.getValue()).append("\n");
         }
 
         final List<String> h2 = new ArrayList<>();
@@ -350,13 +346,11 @@ public class ExternalBinaryContent extends AbstractTest {
             h2.add(h.getName());
         }
 
-        final Set set1 = new HashSet(Arrays.asList(h1));
-        final Set set2 = new HashSet(Arrays.asList(h2));
+        final Set set1 = new HashSet(Collections.singletonList(h1));
+        final Set set2 = new HashSet(Collections.singletonList(h2));
 
-        if (set2.containsAll(set1)) {
-            Assert.assertTrue(true, "OK");
-        } else {
-            Assert.assertTrue(false, "FAIL");
+        if (!set2.containsAll(set1)) {
+            Assert.fail();
         }
 
     }
@@ -368,7 +362,7 @@ public class ExternalBinaryContent extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void putUpdateCheckHeaders(final String uri) throws FileNotFoundException {
+    public void putUpdateCheckHeaders(final String uri) {
         final TestInfo info = setupTest("3.9-E-2", "putUpdateCheckHeaders",
                                         "Fedora servers receiving requests that would create or update an LDP-NR with" +
                                         " Content-Type: "
@@ -391,11 +385,11 @@ public class ExternalBinaryContent extends AbstractTest {
                            .when()
                            .put(locationHeader);
 
-        ps.append(putup.getStatusLine() + "\n");
+        ps.append(putup.getStatusLine()).append("\n");
         final Headers headers = putup.getHeaders();
         for (Header h : headers) {
-            ps.append(h.getName() + ": ");
-            ps.append(h.getValue() + "\n");
+            ps.append(h.getName()).append(": ");
+            ps.append(h.getValue()).append("\n");
         }
         final List<String> h1 = new ArrayList<>();
         for (Header h : headers) {
@@ -432,11 +426,11 @@ public class ExternalBinaryContent extends AbstractTest {
                                                .when()
                                                .put(locationHeader3);
 
-        ps.append(resext.getStatusLine() + "\n");
+        ps.append(resext.getStatusLine()).append("\n");
         final Headers headersext = resext.getHeaders();
         for (Header h : headersext) {
-            ps.append(h.getName() + ": ");
-            ps.append(h.getValue() + "\n");
+            ps.append(h.getName()).append(": ");
+            ps.append(h.getValue()).append("\n");
         }
 
         final List<String> h2 = new ArrayList<>();
@@ -444,13 +438,11 @@ public class ExternalBinaryContent extends AbstractTest {
             h2.add(h.getName());
         }
 
-        final Set set1 = new HashSet(Arrays.asList(h1));
-        final Set set2 = new HashSet(Arrays.asList(h2));
+        final Set set1 = new HashSet(Collections.singletonList(h1));
+        final Set set2 = new HashSet(Collections.singletonList(h2));
 
-        if (set2.containsAll(set1)) {
-            Assert.assertTrue(true, "OK");
-        } else {
-            Assert.assertTrue(false, "FAIL");
+        if (!set2.containsAll(set1)) {
+            Assert.fail();
         }
 
     }
@@ -462,7 +454,7 @@ public class ExternalBinaryContent extends AbstractTest {
      */
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
-    public void getCheckContentLocationHeader(final String uri) throws FileNotFoundException {
+    public void getCheckContentLocationHeader(final String uri) {
         final TestInfo info = setupTest("3.9-F-1", "getCheckContentLocationHeader",
                                         "GET and HEAD responses for any external LDP-NR should include a " +
                                         "Content-Location header with a URI  "
@@ -487,21 +479,22 @@ public class ExternalBinaryContent extends AbstractTest {
         final String locationHeader2 = getLocation(resource);
 
         ps.append("Request method:\tGET\n");
-        ps.append("Request URI:\t" + uri);
+        ps.append("Request URI:\t").append(uri);
         ps.append("Headers:\tAccept=*/*\n");
-        ps.append("\t\t\t\tContent-Type=message/external-body; access-type=URL; URL=\"" + locationHeader1 + "\"\n\n");
+        ps.append("\t\t\t\tContent-Type=message/external-body; access-type=URL; URL=\"").append(locationHeader1);
+        ps.append("\"\n\n");
 
         final Headers headers = doGet(locationHeader2).getHeaders();
 
         for (Header h : headers) {
-            ps.append(h.getName() + ": ");
-            ps.append(h.getValue() + "\n");
+            ps.append(h.getName()).append(": ");
+            ps.append(h.getValue()).append("\n");
         }
 
         if (locationHeader2.indexOf("http") == 0) {
             boolean isValid = false;
             for (Header h : headers) {
-                if (h.getName().equals("Content-location") && h.getValue() != " ") {
+                if (h.getName().equals("Content-location") && !Objects.equals(h.getValue(), " ")) {
                     isValid = true;
                 }
             }
@@ -524,7 +517,7 @@ public class ExternalBinaryContent extends AbstractTest {
      */
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
-    public void headCheckContentLocationHeader(final String uri) throws FileNotFoundException {
+    public void headCheckContentLocationHeader(final String uri) {
         final TestInfo info = setupTest("3.9-F-2", "headCheckContentLocationHeader",
                                         "GET and HEAD responses for any external LDP-NR should include a " +
                                         "Content-Location header with a URI  "
@@ -550,22 +543,23 @@ public class ExternalBinaryContent extends AbstractTest {
         final String locationHeader2 = getLocation(resource);
 
         ps.append("Request method:\tHEAD\n");
-        ps.append("Request URI:\t" + uri);
+        ps.append("Request URI:\t").append(uri);
         ps.append("Headers:\tAccept=*/*\n");
-        ps.append("\t\t\t\tContent-Type=message/external-body; access-type=URL; URL=\"" + locationHeader1 + "\"\n\n");
+        ps.append("\t\t\t\tContent-Type=message/external-body; access-type=URL; URL=\"").append(locationHeader1);
+        ps.append("\"\n\n");
 
         final Headers headers = createRequest().when()
                                                .head(locationHeader2).getHeaders();
 
         for (Header h : headers) {
-            ps.append(h.getName() + ": ");
-            ps.append(h.getValue() + "\n");
+            ps.append(h.getName()).append(": ");
+            ps.append(h.getValue()).append("\n");
         }
 
         if (locationHeader2.indexOf("http") == 0) {
             boolean isValid = false;
             for (Header h : headers) {
-                if (h.getName().equals("Content-Location") && h.getValue() != " ") {
+                if (h.getName().equals("Content-Location") && !Objects.equals(h.getValue(), " ")) {
                     isValid = true;
                 }
             }
@@ -588,7 +582,7 @@ public class ExternalBinaryContent extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void respondWantDigestExternalBinaryContent(final String uri) throws FileNotFoundException {
+    public void respondWantDigestExternalBinaryContent(final String uri) {
         final TestInfo info = setupTest("3.9-G-1", "respondWantDigestExternalBinaryContent",
                                         "GET and HEAD requests to any external LDP-NR must correctly respond to the "
                                         + "Want-Digest header defined in [RFC3230].",
@@ -626,7 +620,7 @@ public class ExternalBinaryContent extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void respondWantDigestExternalBinaryContentHead(final String uri) throws FileNotFoundException {
+    public void respondWantDigestExternalBinaryContentHead(final String uri) {
         final TestInfo info = setupTest("3.9-G-2", "respondWantDigestExternalBinaryContentHead",
                                         "GET and HEAD requests to any external LDP-NR must correctly respond to the "
                                         + "Want-Digest header defined in [RFC3230].",
@@ -668,7 +662,7 @@ public class ExternalBinaryContent extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void respondWantDigestTwoSupportedExternalBinaryContent(final String uri) throws FileNotFoundException {
+    public void respondWantDigestTwoSupportedExternalBinaryContent(final String uri) {
         final TestInfo info =
             setupTest("3.9-H-1", "respondWantDigestTwoSupportedExternalBinaryContent",
                       "GET and HEAD requests to any external LDP-NR must correctly respond to the "
@@ -700,7 +694,7 @@ public class ExternalBinaryContent extends AbstractTest {
         ps.append(wantDigestResponse.getStatusLine());
 
         for (Header h : headers) {
-            ps.append(h.getName() + ": " + h.getValue() + "\n");
+            ps.append(h.getName()).append(": ").append(h.getValue()).append("\n");
         }
 
         Assert.assertTrue(headers.getValue(DIGEST).contains("md5") ||
@@ -715,7 +709,7 @@ public class ExternalBinaryContent extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void respondWantDigestTwoSupportedExternalBinaryContentHead(final String uri) throws FileNotFoundException {
+    public void respondWantDigestTwoSupportedExternalBinaryContentHead(final String uri) {
         final TestInfo info =
             setupTest("3.9-H-2", "respondWantDigestTwoSupportedExternalBinaryContentHead",
                       "GET and HEAD requests to any external LDP-NR must correctly respond to the "
@@ -748,7 +742,7 @@ public class ExternalBinaryContent extends AbstractTest {
         ps.append(wantDigestResponse.getStatusLine());
 
         for (Header h : headers) {
-            ps.append(h.getName() + ": " + h.getValue() + "\n");
+            ps.append(h.getName()).append(": ").append(h.getValue()).append("\n");
         }
 
         Assert.assertTrue(headers.getValue(DIGEST).contains("md5") ||
@@ -763,8 +757,7 @@ public class ExternalBinaryContent extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void respondWantDigestTwoSupportedQvalueNonZeroExternalBinaryContent(final String uri)
-        throws FileNotFoundException {
+    public void respondWantDigestTwoSupportedQvalueNonZeroExternalBinaryContent(final String uri) {
         final TestInfo info = setupTest("3.9-I-1",
                                         "" +
                                         "respondWantDigestTwoSupportedQvalueNonZeroExternalBinaryContent",
@@ -800,7 +793,7 @@ public class ExternalBinaryContent extends AbstractTest {
         ps.append(wantDigestResponse.getStatusLine());
 
         for (Header h : headers) {
-            ps.append(h.getName() + ": " + h.getValue() + "\n");
+            ps.append(h.getName()).append(": ").append(h.getValue()).append("\n");
         }
 
         Assert.assertTrue(headers.getValue(DIGEST).contains("md5") ||
@@ -815,8 +808,7 @@ public class ExternalBinaryContent extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void respondWantDigestTwoSupportedQvalueNonZeroExternalBinaryContentHead(final String uri)
-        throws FileNotFoundException {
+    public void respondWantDigestTwoSupportedQvalueNonZeroExternalBinaryContentHead(final String uri) {
         final TestInfo info = setupTest("3.9-I-2",
                                         "respondWantDigestTwoSupportedQvalueNonZeroExternalBinaryContentHead",
                                         "GET and HEAD requests to any external LDP-NR must correctly respond to the "
@@ -851,7 +843,7 @@ public class ExternalBinaryContent extends AbstractTest {
         ps.append(wantDigestResponse.getStatusLine());
 
         for (Header h : headers) {
-            ps.append(h.getName() + ": " + h.getValue() + "\n");
+            ps.append(h.getName()).append(": ").append(h.getValue()).append("\n");
         }
 
         Assert.assertTrue(headers.getValue(DIGEST).contains("md5") ||
@@ -866,8 +858,7 @@ public class ExternalBinaryContent extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void respondWantDigestNonSupportedExternalBinaryContent(final String uri)
-        throws FileNotFoundException {
+    public void respondWantDigestNonSupportedExternalBinaryContent(final String uri) {
         final TestInfo info =
             setupTest("3.9.3-A", "respondWantDigestNonSupportedExternalBinaryContent",
                       "GET and HEAD requests to any external LDP-NR must correctly respond to the "
@@ -907,8 +898,7 @@ public class ExternalBinaryContent extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void respondWantDigestNonSupportedExternalBinaryContentHead(final String uri)
-        throws FileNotFoundException {
+    public void respondWantDigestNonSupportedExternalBinaryContentHead(final String uri) {
         final TestInfo info =
             setupTest("3.9.3-B", "respondWantDigestNonSupportedExternalBinaryContentHead",
                       "GET and HEAD requests to any external LDP-NR must correctly respond to the "

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/HttpDelete.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/HttpDelete.java
@@ -20,8 +20,6 @@ package org.fcrepo.spec.testsuite.crud;
 import static org.fcrepo.spec.testsuite.Constants.CONTENT_DISPOSITION;
 import static org.fcrepo.spec.testsuite.Constants.SLUG;
 
-import java.io.FileNotFoundException;
-
 import io.restassured.RestAssured;
 import io.restassured.http.Header;
 import io.restassured.http.Headers;
@@ -55,7 +53,7 @@ public class HttpDelete extends AbstractTest {
      */
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
-    public void httpDeleteOptionsCheck(final String uri) throws FileNotFoundException {
+    public void httpDeleteOptionsCheck(final String uri) {
         final TestInfo info = setupTest("3.8.1-A", "httpDeleteOptionsCheck",
                                         "An implementation that cannot recurse should not advertise DELETE in " +
                                         "response to OPTIONS "
@@ -95,7 +93,7 @@ public class HttpDelete extends AbstractTest {
         final String rlocationHeader3 = getLocation(rdf03);
 
         ps.append("Request method:\tDELETE\n");
-        ps.append("Request URI:\t" + uri + "\n");
+        ps.append("Request URI:\t").append(uri).append("\n");
         ps.append("Headers:\tAccept=*/*\n");
         ps.append("Body:\n");
 
@@ -111,10 +109,10 @@ public class HttpDelete extends AbstractTest {
 
         // Print headers and status
         final Headers headers = response.getHeaders();
-        ps.append(response.getStatusLine().toString());
+        ps.append(response.getStatusLine());
 
         for (Header h : headers) {
-            ps.append(h.getName().toString() + ": " + h.getValue().toString() + "\n");
+            ps.append(h.getName()).append(": ").append(h.getValue()).append("\n");
         }
 
         //GET deleted resources
@@ -125,22 +123,15 @@ public class HttpDelete extends AbstractTest {
         final Response resRdf03 = doGet(rlocationHeader3);
 
         if (allowHeader.contains("OPTIONS")) {
-            if (resResource.getStatusCode() == 410 || resResourceSon.getStatusCode() == 410 ||
+            if (resResource.getStatusCode() != 410 && resResourceSon.getStatusCode() != 410 &&
+                resRdf01.getStatusCode() != 410 && resRdf02.getStatusCode() != 410 &&
+                resRdf03.getStatusCode() != 410) {
+                Assert.fail();
+            }
+        } else if (resResource.getStatusCode() == 410 || resResourceSon.getStatusCode() == 410 ||
                 resRdf01.getStatusCode() == 410 || resRdf02.getStatusCode() == 410 ||
                 resRdf03.getStatusCode() == 410) {
-                Assert.assertTrue(true, "OK");
-            } else {
-                Assert.assertTrue(false, "FAIL");
-            }
-        } else {
-            if (resResource.getStatusCode() == 410 || resResourceSon.getStatusCode() == 410 ||
-                resRdf01.getStatusCode() == 410 || resRdf02.getStatusCode() == 410 ||
-                resRdf03.getStatusCode() == 410) {
-                Assert.assertTrue(false, "FAIL");
-            } else {
-                Assert.assertTrue(true, "OK");
-            }
-
+                Assert.fail();
         }
 
     }
@@ -152,7 +143,7 @@ public class HttpDelete extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void httpDeleteStatusCheck(final String uri) throws FileNotFoundException {
+    public void httpDeleteStatusCheck(final String uri) {
         final TestInfo info = setupTest("3.8.1-C", "httpDeleteStatusCheck",
                                         "An implementation must not return a 200 (OK) or 204 (No Content) response "
                                         + "unless the entire operation successfully completed.",
@@ -188,7 +179,7 @@ public class HttpDelete extends AbstractTest {
         final String rlocationHeader3 = getLocation(nrdf03);
 
         ps.append("Request method:\tDELETE\n");
-        ps.append("Request URI:\t" + uri + "\n");
+        ps.append("Request URI:\t").append(uri).append("\n");
         ps.append("Headers:\tAccept=*/*\n");
         ps.append("Body:\n");
 
@@ -199,10 +190,10 @@ public class HttpDelete extends AbstractTest {
         // Print headers and status
         final int statusDelete = response.getStatusCode();
         final Headers headers = response.getHeaders();
-        ps.append(response.getStatusLine().toString());
+        ps.append(response.getStatusLine());
 
         for (Header h : headers) {
-            ps.append(h.getName().toString() + ": " + h.getValue().toString() + "\n");
+            ps.append(h.getName()).append(": ").append(h.getValue()).append("\n");
         }
 
         //GET deleted resources
@@ -213,20 +204,16 @@ public class HttpDelete extends AbstractTest {
         final Response resRdf03 = doGet(rlocationHeader3);
 
         if (statusDelete == 200 || statusDelete == 204) {
-            if (resResource.getStatusCode() == 410 || resResourceSon.getStatusCode() == 410 ||
-                resRdf01.getStatusCode() == 410 || resRdf02.getStatusCode() == 410 ||
-                resRdf03.getStatusCode() == 410) {
-                Assert.assertTrue(true, "OK");
-            } else {
-                Assert.assertTrue(false, "FAIL");
+            if (resResource.getStatusCode() != 410 && resResourceSon.getStatusCode() != 410 &&
+                resRdf01.getStatusCode() != 410 && resRdf02.getStatusCode() != 410 &&
+                resRdf03.getStatusCode() != 410) {
+                Assert.fail();
             }
         } else {
             if (resResource.getStatusCode() == 410 || resResourceSon.getStatusCode() == 410 ||
                 resRdf01.getStatusCode() == 410 || resRdf02.getStatusCode() == 410 ||
                 resRdf03.getStatusCode() == 410) {
-                Assert.assertTrue(false, "FAIL");
-            } else {
-                Assert.assertTrue(true, "OK");
+                Assert.fail();
             }
         }
     }
@@ -238,7 +225,7 @@ public class HttpDelete extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void httpDeleteStatusCheckTwo(final String uri) throws FileNotFoundException {
+    public void httpDeleteStatusCheckTwo(final String uri) {
         final TestInfo info = setupTest("3.8.1-D", "httpDeleteStatusCheckTwo",
                                         "An implementation must not emit a message that implies the successful DELETE" +
                                         " of a resource until "
@@ -282,7 +269,7 @@ public class HttpDelete extends AbstractTest {
         final String rlocationHeader3 = getLocation(nrdf03);
 
         ps.append("Request method:\tDELETE\n");
-        ps.append("Request URI:\t" + uri + "\n");
+        ps.append("Request URI:\t").append(uri).append("\n");
         ps.append("Headers:\tAccept=*/*\n");
         ps.append("Body:\n");
 
@@ -293,10 +280,10 @@ public class HttpDelete extends AbstractTest {
         // Print headers and status
         final int statusDelete = response.getStatusCode();
         final Headers headers = response.getHeaders();
-        ps.append(response.getStatusLine().toString());
+        ps.append(response.getStatusLine());
 
         for (Header h : headers) {
-            ps.append(h.getName().toString() + ": " + h.getValue().toString() + "\n");
+            ps.append(h.getName()).append(": ").append(h.getValue()).append("\n");
         }
 
         //GET deleted resources
@@ -308,20 +295,16 @@ public class HttpDelete extends AbstractTest {
 
         final String statusdeletestring = String.valueOf(statusDelete);
         if (statusdeletestring.charAt(0) == '2') {
-            if (resResource.getStatusCode() == 410 || resResourceSon.getStatusCode() == 410 ||
-                resRdf01.getStatusCode() == 410 || resRdf02.getStatusCode() == 410 ||
-                resRdf03.getStatusCode() == 410) {
-                Assert.assertTrue(true, "OK");
-            } else {
-                Assert.assertTrue(false, "FAIL");
+            if (resResource.getStatusCode() != 410 && resResourceSon.getStatusCode() != 410 &&
+                resRdf01.getStatusCode() != 410 && resRdf02.getStatusCode() != 410 &&
+                resRdf03.getStatusCode() != 410) {
+                Assert.fail();
             }
         } else {
             if (resResource.getStatusCode() == 410 || resResourceSon.getStatusCode() == 410 ||
                 resRdf01.getStatusCode() == 410 || resRdf02.getStatusCode() == 410 ||
                 resRdf03.getStatusCode() == 410) {
-                Assert.assertTrue(false, "FAIL");
-            } else {
-                Assert.assertTrue(true, "OK");
+                Assert.fail();
             }
         }
     }

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/HttpGet.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/HttpGet.java
@@ -23,7 +23,6 @@ import static org.fcrepo.spec.testsuite.Constants.RDF_BODY;
 import static org.fcrepo.spec.testsuite.Constants.SLUG;
 import static org.hamcrest.Matchers.containsString;
 
-import java.io.FileNotFoundException;
 import java.net.URI;
 import java.util.List;
 
@@ -65,7 +64,7 @@ public class HttpGet extends AbstractTest {
      */
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
-    public void additionalValuesForPreferHeader(final String uri) throws FileNotFoundException {
+    public void additionalValuesForPreferHeader(final String uri) {
         final TestInfo info = setupTest("3.2.1-A", "additionalValuesForPreferHeader",
                                         "In addition to the requirements of [LDP], an implementation ... " +
                                         "should support the value " +
@@ -104,7 +103,7 @@ public class HttpGet extends AbstractTest {
      */
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
-    public void additionalValuesForPreferHeaderContainedDescriptions(final String uri) throws FileNotFoundException {
+    public void additionalValuesForPreferHeaderContainedDescriptions(final String uri) {
         final TestInfo info = setupTest("3.2.1-B", "additionalValuesForPreferHeaderContainedDescriptions",
                 "In addition to the requirements of [LDP], an implementation ... " +
                         "may support the value " +
@@ -140,7 +139,7 @@ public class HttpGet extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void responsePreferenceAppliedHeader(final String uri) throws FileNotFoundException {
+    public void responsePreferenceAppliedHeader(final String uri) {
         final TestInfo info = setupTest("3.2.2-A", "responsePreferenceAppliedHeader",
                                         "Responses to GET requests that apply a Prefer request header to any LDP-RS " +
                                         "must "
@@ -167,7 +166,7 @@ public class HttpGet extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void responseDescribesHeader(final String uri) throws FileNotFoundException {
+    public void responseDescribesHeader(final String uri) {
         final TestInfo info = setupTest("3.2.2-B", "responseDescribesHeader",
                                         "When a GET request is made to an LDP-RS that describes an associated LDP-NR "
                                         + "(3.5 HTTP POST and [LDP]5.2.3.12),"
@@ -213,7 +212,7 @@ public class HttpGet extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void respondWantDigest(final String uri) throws FileNotFoundException {
+    public void respondWantDigest(final String uri) {
         final TestInfo info = setupTest("3.2.3-A", "respondWantDigest",
                                         "Testing for supported digest "
                                         + "GET requests to any LDP-NR must correctly respond to the Want-Digest "
@@ -245,7 +244,7 @@ public class HttpGet extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void respondWantDigestTwoSupported(final String uri) throws FileNotFoundException {
+    public void respondWantDigestTwoSupported(final String uri) {
         final String checksum = "md5,sha";
         final TestInfo info = setupTest("3.2.3-B", "respondWantDigestTwoSupported",
                                         "Testing for two supported digests with no weights"
@@ -269,7 +268,7 @@ public class HttpGet extends AbstractTest {
         ps.append(wantDigestResponse.getStatusLine());
 
         for (Header h : headers) {
-            ps.append(h.getName() + ": " + h.getValue() + "\n");
+            ps.append(h.getName()).append(": ").append(h.getValue()).append("\n");
         }
 
         Assert
@@ -285,7 +284,7 @@ public class HttpGet extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void respondWantDigestTwoSupportedQvalueNonZero(final String uri) throws FileNotFoundException {
+    public void respondWantDigestTwoSupportedQvalueNonZero(final String uri) {
         final String checksum = "md5;q=0.3,sha;q=1";
         final TestInfo info = setupTest("3.2.3-C", "respondWantDigestTwoSupportedQvalueNonZero",
                                         "Testing for two supported digests with different weights"
@@ -310,7 +309,7 @@ public class HttpGet extends AbstractTest {
         ps.append(wantDigestResponse.getStatusLine());
 
         for (Header h : headers) {
-            ps.append(h.getName() + ": " + h.getValue() + "\n");
+            ps.append(h.getName()).append(": ").append(h.getValue()).append("\n");
         }
 
         Assert
@@ -326,7 +325,7 @@ public class HttpGet extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void respondWantDigestTwoSupportedQvalueZero(final String uri) throws FileNotFoundException {
+    public void respondWantDigestTwoSupportedQvalueZero(final String uri) {
         final String checksum = "md5;q=0.3,sha;q=0";
         final TestInfo info = setupTest("3.2.3-D", "respondWantDigestTwoSupportedQvalueZero",
                                         "Testing for two supported digests with different weights q=0.3,q=0"
@@ -357,7 +356,7 @@ public class HttpGet extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void respondWantDigestNonSupported(final String uri) throws FileNotFoundException {
+    public void respondWantDigestNonSupported(final String uri) {
         final String checksum = "md5,abc";
 
         final TestInfo info = setupTest("3.2.3-E", "respondWantDigestNonSupported",

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/HttpHead.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/HttpHead.java
@@ -22,7 +22,6 @@ import static org.fcrepo.spec.testsuite.Constants.DIGEST;
 import static org.fcrepo.spec.testsuite.Constants.SLUG;
 import static org.hamcrest.Matchers.equalTo;
 
-import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -59,7 +58,7 @@ public class HttpHead extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void httpHeadResponseNoBody(final String uri) throws FileNotFoundException {
+    public void httpHeadResponseNoBody(final String uri) {
         final TestInfo info = setupTest("3.3-A", "httpHeadResponseNoBody",
                                         "The HEAD method is identical to GET except that the server must not return a "
                                         + "message-body in the response, as "
@@ -67,7 +66,6 @@ public class HttpHead extends AbstractTest {
                                         "https://fcrepo.github.io/fcrepo-specification/#http-head",
                                         ps);
         final Response resource = createBasicContainer(uri, info);
-        ;
         final String locationHeader = getLocation(resource);
         createRequest().when()
                        .head(locationHeader)
@@ -84,7 +82,7 @@ public class HttpHead extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void httpHeadResponseDigest(final String uri) throws FileNotFoundException {
+    public void httpHeadResponseDigest(final String uri) {
         final TestInfo info = setupTest("3.3-B", "httpHeadResponseDigest",
                                         "The server must send the same Digest header in the response as it"
                                         +
@@ -103,39 +101,33 @@ public class HttpHead extends AbstractTest {
         final Response resget = createRequest().when()
                                                .get(locationHeader);
 
-        ps.append(resget.getStatusLine().toString() + "\n");
+        ps.append(resget.getStatusLine()).append("\n");
         final Headers headersGet = resget.getHeaders();
         for (Header h : headersGet) {
-            ps.append(h.getName().toString() + ": ");
-            ps.append(h.getValue().toString() + "\n");
+            ps.append(h.getName()).append(": ");
+            ps.append(h.getValue()).append("\n");
         }
 
         final Response reshead = createRequest().when()
                                                 .head(locationHeader);
-        ps.append(reshead.getStatusLine().toString() + "\n");
+        ps.append(reshead.getStatusLine()).append("\n");
         final Headers headers = reshead.getHeaders();
         for (Header h : headers) {
-            ps.append(h.getName().toString() + ": ");
-            ps.append(h.getValue().toString() + "\n");
+            ps.append(h.getName()).append(": ");
+            ps.append(h.getValue()).append("\n");
         }
 
         if (resget.getStatusCode() == 200 && reshead.getStatusCode() == 200) {
 
             if (resget.getHeader(DIGEST) == null) {
-                if (reshead.getHeader(DIGEST) == null) {
-                    Assert.assertTrue(true, "OK");
-                } else {
-                    Assert.assertTrue(false, "FAIL");
+                if (reshead.getHeader(DIGEST) != null) {
+                    Assert.fail();
                 }
-            } else {
-                if (reshead.getHeader(DIGEST) == null) {
-                    Assert.assertTrue(false, "FAIL");
-                } else {
-                    Assert.assertTrue(true, "OK");
-                }
+            } else if (reshead.getHeader(DIGEST) == null) {
+                Assert.fail();
             }
         } else {
-            Assert.assertTrue(false, "FAIL");
+            Assert.fail();
         }
     }
 
@@ -146,7 +138,7 @@ public class HttpHead extends AbstractTest {
      */
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
-    public void httpHeadResponseHeadersSameAsHttpGet(final String uri) throws FileNotFoundException {
+    public void httpHeadResponseHeadersSameAsHttpGet(final String uri) {
         final TestInfo info = setupTest("3.3-C", "httpHeadResponseHeadersSameAsHttpGet",
                                         "In other cases, The server should send the same headers in response to a " +
                                         "HEAD request "
@@ -162,11 +154,11 @@ public class HttpHead extends AbstractTest {
             .when()
             .get(locationHeader);
 
-        ps.append(resget.getStatusLine().toString() + "\n");
+        ps.append(resget.getStatusLine()).append("\n");
         final Headers headersGet = resget.getHeaders();
         for (Header h : headersGet) {
-            ps.append(h.getName().toString() + ": ");
-            ps.append(h.getValue().toString() + "\n");
+            ps.append(h.getName()).append(": ");
+            ps.append(h.getValue()).append("\n");
         }
 
         final List<Header> h1 = new ArrayList<>();
@@ -179,11 +171,11 @@ public class HttpHead extends AbstractTest {
         final Response reshead = createRequest().when()
                                                 .head(locationHeader);
 
-        ps.append(reshead.getStatusLine().toString() + "\n");
+        ps.append(reshead.getStatusLine()).append("\n");
         final Headers headershead = reshead.getHeaders();
         for (Header h : headershead) {
-            ps.append(h.getName().toString() + ": ");
-            ps.append(h.getValue().toString() + "\n");
+            ps.append(h.getName()).append(": ");
+            ps.append(h.getValue()).append("\n");
         }
         final List<Header> h2 = new ArrayList<>();
         for (Header h : headershead) {
@@ -192,10 +184,8 @@ public class HttpHead extends AbstractTest {
             }
         }
         // Compares if both lists have the same size
-        if (h2.equals(h1)) {
-            Assert.assertTrue(true, "OK");
-        } else {
-            Assert.assertTrue(false, "FAIL");
+        if (!h2.equals(h1)) {
+            Assert.fail();
         }
 
     }

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/HttpOptions.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/HttpOptions.java
@@ -19,8 +19,6 @@ package org.fcrepo.spec.testsuite.crud;
 
 import static org.hamcrest.Matchers.containsString;
 
-import java.io.FileNotFoundException;
-
 import org.fcrepo.spec.testsuite.AbstractTest;
 import org.fcrepo.spec.testsuite.TestInfo;
 import org.testng.annotations.Parameters;
@@ -49,7 +47,7 @@ public class HttpOptions extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void httpOptionsSupport(final String uri) throws FileNotFoundException {
+    public void httpOptionsSupport(final String uri) {
         final TestInfo info = setupTest("3.4-A", "httpOptionsSupport",
                                         "Any LDPR must support OPTIONS per [LDP] 4.2.8. "
                                         + "4.2.8.1 LDP servers must support the HTTP OPTIONS method.",
@@ -70,7 +68,7 @@ public class HttpOptions extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void httpOptionsSupportAllow(final String uri) throws FileNotFoundException {
+    public void httpOptionsSupportAllow(final String uri) {
         final TestInfo info = setupTest("3.4-B", "httpOptionsSupportAllow",
                                         "Any LDPR must support OPTIONS per [LDP] 4.2.8. "
                                         + "LDP servers must indicate their support for HTTP Methods by responding to a"

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPatch.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPatch.java
@@ -21,9 +21,6 @@ import static org.fcrepo.spec.testsuite.Constants.APPLICATION_SPARQL_UPDATE;
 import static org.fcrepo.spec.testsuite.Constants.BASIC_CONTAINER_BODY;
 import static org.hamcrest.CoreMatchers.containsString;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-
 import io.restassured.RestAssured;
 import io.restassured.config.EncoderConfig;
 import io.restassured.config.LogConfig;
@@ -41,27 +38,27 @@ import org.testng.annotations.Test;
  */
 public class HttpPatch extends AbstractTest {
 
-    public String body = "PREFIX dcterms: <http://purl.org/dc/terms/>"
+    private final String body = "PREFIX dcterms: <http://purl.org/dc/terms/>"
                          + " INSERT {"
                          + " <> dcterms:description \"Patch Updated Description\" ."
                          + "}"
                          + " WHERE { }";
-    public String ldpatch = "@prefix dcterms: <http://purl.org/dc/terms/>"
+    private final String ldpatch = "@prefix dcterms: <http://purl.org/dc/terms/>"
                             + "Add {"
                             + " <#> dcterms:description \"Patch LDP Updated Description\" ;"
                             + "} .";
-    public String serverProps = "PREFIX fedora: <http://fedora.info/definitions/v4/repository#>"
+    private final String serverProps = "PREFIX fedora: <http://fedora.info/definitions/v4/repository#>"
                                 + " INSERT {"
                                 + " <> fedora:lastModifiedBy \"User\" ."
                                 + "}"
                                 + " WHERE { }";
-    public String resourceType = "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>"
+    private final String resourceType = "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>"
                                  + " PREFIX ldp: <http://www.w3.org/ns/ldp#>"
                                  + " INSERT {"
                                  + " <> rdf:type ldp:NonRDFSource ."
                                  + "}"
                                  + " WHERE { }";
-    public String updateContainmentTriples = "PREFIX ldp: <http://www.w3.org/ns/ldp#>\n"
+    private final String updateContainmentTriples = "PREFIX ldp: <http://www.w3.org/ns/ldp#>\n"
                                              + " INSERT {   \n"
                                              + "  <> ldp:contains \"some-url\" .\n"
                                              + "}\n"
@@ -85,7 +82,7 @@ public class HttpPatch extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void supportPatch(final String uri) throws IOException {
+    public void supportPatch(final String uri) {
         final TestInfo info = setupTest("3.7-A", "supportPatch",
                                         "Any LDP-RS must support PATCH ([LDP] 4.2.7 may becomes must). " +
                                         "[sparql11-update] must be an accepted "
@@ -117,7 +114,7 @@ public class HttpPatch extends AbstractTest {
      */
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
-    public void ldpPatchContentTypeSupport(final String uri) throws IOException {
+    public void ldpPatchContentTypeSupport(final String uri) {
         final TestInfo info = setupTest("3.7-B", "ldpPatchContentTypeSupport",
                                         "Other content-types (e.g. [ldpatch]) may be available.",
                                         "https://fcrepo.github.io/fcrepo-specification/#http-patch", ps);
@@ -145,7 +142,7 @@ public class HttpPatch extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void serverManagedPropertiesModification(final String uri) throws IOException {
+    public void serverManagedPropertiesModification(final String uri) {
         final TestInfo info = setupTest("3.7-C", "serverManagedPropertiesModification",
                                         "If an otherwise valid HTTP PATCH request is received that attempts to modify "
                                         + "statements to a resource that a server disallows (not ignores per [LDP] "
@@ -177,7 +174,7 @@ public class HttpPatch extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void statementNotPersistedResponseBody(final String uri) throws IOException {
+    public void statementNotPersistedResponseBody(final String uri) {
         final TestInfo info = setupTest("3.7-D", "statementNotPersistedResponseBody",
                                         "The server must provide a corresponding response body containing information"
                                         + " about which statements could not be persisted."
@@ -208,7 +205,7 @@ public class HttpPatch extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void statementNotPersistedConstrainedBy(final String uri) throws IOException {
+    public void statementNotPersistedConstrainedBy(final String uri) {
         final TestInfo info = setupTest("3.7-E", "statementNotPersistedConstrainedBy",
                                         "In that response, the restrictions causing such a request to fail must be"
                                         + " described in a resource indicated by a Link: "
@@ -240,7 +237,7 @@ public class HttpPatch extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void successfulPatchStatusCode(final String uri) throws IOException {
+    public void successfulPatchStatusCode(final String uri) {
         final TestInfo info = setupTest("3.7-F", "successfulPatchStatusCode",
                                         "A successful PATCH request must respond with a 2xx status code; the "
                                         + "specific code in the 2xx range may vary according to the response "
@@ -249,7 +246,7 @@ public class HttpPatch extends AbstractTest {
         final Response resource = createBasicContainer(uri, info);
         final String locationHeader = getLocation(resource);
         ps.append("Request method:\tPATCH\n");
-        ps.append("Request URI:\t" + uri);
+        ps.append("Request URI:\t").append(uri);
         ps.append("Headers:\tAccept=*/*\n");
         ps.append("\t\t\t\tContent-Type=application/sparql-update; charset=ISO-8859-1\n");
         ps.append("Body:\n");
@@ -267,12 +264,12 @@ public class HttpPatch extends AbstractTest {
         final int statusCode = response.getStatusCode();
         final Headers headers = response.getHeaders();
 
-        ps.append("HTTP/1.1 " + statusCode + "\n");
+        ps.append("HTTP/1.1 ").append(String.valueOf(statusCode)).append("\n");
         for (Header h : headers) {
-            ps.append(h.getName() + ": " + h.getValue() + "\n");
+            ps.append(h.getName()).append(": ").append(h.getValue()).append("\n");
         }
 
-        String str = "";
+        String str;
         boolean err = false;
         if (statusCode >= 200 && statusCode < 300) {
             str = "\n" + response.asString();
@@ -297,7 +294,7 @@ public class HttpPatch extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void disallowPatchContainmentTriples(final String uri) throws FileNotFoundException {
+    public void disallowPatchContainmentTriples(final String uri) {
         final TestInfo info = setupTest("3.7.1", "disallowPatchContainmentTriples",
                                         "The server should not allow HTTP PATCH to update an LDPC’s containment " +
                                         "triples; if"
@@ -332,7 +329,7 @@ public class HttpPatch extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void disallowChangeResourceType(final String uri) throws IOException {
+    public void disallowChangeResourceType(final String uri) {
         final TestInfo info = setupTest("3.7.2", "disallowChangeResourceType",
                                         "The server must disallow a PATCH request that would change the LDP"
                                         + " interaction model of a resource to a type that is not a subtype"

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPost.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPost.java
@@ -22,8 +22,6 @@ import static org.fcrepo.spec.testsuite.Constants.DIGEST;
 import static org.fcrepo.spec.testsuite.Constants.SLUG;
 import static org.hamcrest.Matchers.containsString;
 
-import java.io.FileNotFoundException;
-
 import org.fcrepo.spec.testsuite.AbstractTest;
 import org.fcrepo.spec.testsuite.TestInfo;
 import org.testng.annotations.Parameters;
@@ -33,10 +31,6 @@ import org.testng.annotations.Test;
  * @author Jorge Abrego, Fernando Cardoza
  */
 public class HttpPost extends AbstractTest {
-    public String username;
-    public String password;
-    public String resource = "";
-    public String binary = "https://www.w3.org/StyleSheets/TR/2016/logos/UD-watermark";
 
     /**
      * Authentication
@@ -56,7 +50,7 @@ public class HttpPost extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void httpPost(final String uri) throws FileNotFoundException {
+    public void httpPost(final String uri) {
         final TestInfo info = setupTest("3.5-A", "httpPost",
                                         "Any LDPC (except Version Containers (LDPCv)) must support POST ([LDP] 4.2.3 " +
                                         "/ 5.2.3). ",
@@ -76,7 +70,7 @@ public class HttpPost extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void constrainedByResponseHeader(final String uri) throws FileNotFoundException {
+    public void constrainedByResponseHeader(final String uri) {
         final TestInfo info = setupTest("3.5-B", "constrainedByResponseHeader",
                                         "The default interaction model that will be assigned when there is no " +
                                         "explicit Link "
@@ -99,7 +93,7 @@ public class HttpPost extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void postNonRDFSource(final String uri) throws FileNotFoundException {
+    public void postNonRDFSource(final String uri) {
         final TestInfo info = setupTest("3.5.1-A", "postNonRDFSource",
                                         "Any LDPC must support creation of LDP-NRs on POST ([LDP] 5.2.3.3 may becomes" +
                                         " must).",
@@ -122,7 +116,7 @@ public class HttpPost extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void postResourceAndCheckAssociatedResource(final String uri) throws FileNotFoundException {
+    public void postResourceAndCheckAssociatedResource(final String uri) {
         final TestInfo info = setupTest("3.5.1-B", "postResourceAndCheckAssociatedResource",
                                         "On creation of an LDP-NR, an implementation must create an associated LDP-RS" +
                                         " describing"
@@ -147,7 +141,7 @@ public class HttpPost extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void postDigestResponseHeaderAuthentication(final String uri) throws FileNotFoundException {
+    public void postDigestResponseHeaderAuthentication(final String uri) {
         final TestInfo info = setupTest("3.5.1-C", "postDigestResponseHeaderAuthentication",
                                         "An HTTP POST request that would create an LDP-NR and includes a Digest " +
                                         "header (as described"
@@ -177,7 +171,7 @@ public class HttpPost extends AbstractTest {
      */
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
-    public void postDigestResponseHeaderVerification(final String uri) throws FileNotFoundException {
+    public void postDigestResponseHeaderVerification(final String uri) {
         final TestInfo info = setupTest("3.5.1-D", "postDigestResponseHeaderVerification",
                                         "An HTTP POST request that includes an unsupported Digest type (as described " +
                                         "in [RFC3230]), "

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPut.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPut.java
@@ -23,8 +23,6 @@ import static org.fcrepo.spec.testsuite.Constants.DIGEST;
 import static org.fcrepo.spec.testsuite.Constants.SLUG;
 import static org.hamcrest.CoreMatchers.containsString;
 
-import java.io.FileNotFoundException;
-
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import org.fcrepo.spec.testsuite.AbstractTest;
@@ -55,7 +53,7 @@ public class HttpPut extends AbstractTest {
      */
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
-    public void httpPut(final String uri) throws FileNotFoundException {
+    public void httpPut(final String uri) {
         final TestInfo info = setupTest("3.6-B", "httpPut",
                                         "When accepting a PUT request against an existant resource, an HTTP Link: " +
                                         "rel=\"type\" header "
@@ -90,11 +88,10 @@ public class HttpPut extends AbstractTest {
      * 3.6.1-A
      *
      * @param uri
-     * @throws FileNotFoundException
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void httpPutpdateTriples(final String uri) throws FileNotFoundException {
+    public void httpPutpdateTriples(final String uri) {
         final TestInfo info = setupTest("3.6.1-A", "httpPutpdateTriples",
                                         "Any LDP-RS must support PUT to update statements that are not server-managed" +
                                         " triples (as defined "
@@ -124,11 +121,10 @@ public class HttpPut extends AbstractTest {
      * 3.6.1-B
      *
      * @param uri
-     * @throws FileNotFoundException
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void httpPutUpdateDisallowedTriples(final String uri) throws FileNotFoundException {
+    public void httpPutUpdateDisallowedTriples(final String uri) {
         final TestInfo info = setupTest("3.6.1-B", "httpPutUpdateDisallowedTriples",
                                         "If an otherwise valid HTTP PUT request is received that attempts to modify " +
                                         "resource "
@@ -165,11 +161,10 @@ public class HttpPut extends AbstractTest {
      * 3.6.1-C
      *
      * @param uri
-     * @throws FileNotFoundException
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void httpPutUpdateDisallowedTriplesResponse(final String uri) throws FileNotFoundException {
+    public void httpPutUpdateDisallowedTriplesResponse(final String uri) {
         final TestInfo info = setupTest("3.6.1-C", "httpPutUpdateDisallowedTriplesResponse",
                                         "The server must provide a corresponding response body containing information "
                                         + "about which statements could"
@@ -200,11 +195,10 @@ public class HttpPut extends AbstractTest {
      * 3.6.1-D
      *
      * @param uri
-     * @throws FileNotFoundException
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void httpPutUpdateDisallowedTriplesConstrainedByHeader(final String uri) throws FileNotFoundException {
+    public void httpPutUpdateDisallowedTriplesConstrainedByHeader(final String uri) {
         final TestInfo info = setupTest("3.6.1-D", "httpPutUpdateDisallowedTriplesConstrainedByHeader",
                                         "In that response, the restrictions causing such a request to fail must be "
                                         + "described in a resource indicated"
@@ -244,7 +238,7 @@ public class HttpPut extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void httpPutNR(final String uri) throws FileNotFoundException {
+    public void httpPutNR(final String uri) {
         final TestInfo info = setupTest("3.6.2-A", "httpPutNR",
                                         "Any LDP-NR must support PUT to replace the binary content of that resource.",
                                         "https://fcrepo.github.io/fcrepo-specification/#http-put-ldpnr", ps);
@@ -273,7 +267,7 @@ public class HttpPut extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void nonRDFSourcePutDigestResponseHeaderAuthentication(final String uri) throws FileNotFoundException {
+    public void nonRDFSourcePutDigestResponseHeaderAuthentication(final String uri) {
         final TestInfo info = setupTest("3.6.2-B", "nonRDFSourcePutDigestResponseHeaderAuthentication",
                                         "An HTTP PUT request that includes a Digest header (as described in " +
                                         "[RFC3230]) for which any "
@@ -308,7 +302,7 @@ public class HttpPut extends AbstractTest {
      */
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
-    public void nonRDFSourcePutDigestResponseHeaderVerification(final String uri) throws FileNotFoundException {
+    public void nonRDFSourcePutDigestResponseHeaderVerification(final String uri) {
         final TestInfo info = setupTest("3.6.2-C", "nonRDFSourcePutDigestResponseHeaderVerification",
                                         "An HTTP PUT request that includes an unsupported Digest type (as described " +
                                         "in [RFC3230]), should"

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/Ldpnr.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/Ldpnr.java
@@ -20,8 +20,6 @@ package org.fcrepo.spec.testsuite.crud;
 import static org.fcrepo.spec.testsuite.Constants.CONTENT_DISPOSITION;
 import static org.fcrepo.spec.testsuite.Constants.SLUG;
 
-import java.io.FileNotFoundException;
-
 import io.restassured.http.Header;
 import io.restassured.response.Response;
 import org.fcrepo.spec.testsuite.AbstractTest;
@@ -54,7 +52,7 @@ public class Ldpnr extends AbstractTest {
      */
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
-    public void ldpnrCreationLinkType(final String uri) throws FileNotFoundException {
+    public void ldpnrCreationLinkType(final String uri) {
         final TestInfo info = setupTest("3.1.2-A", "ldpnrCreationLinkType",
                                         "If, in a successful resource creation request, a Link: rel=\"type\" request " +
                                         "header specifies"
@@ -75,15 +73,15 @@ public class Ldpnr extends AbstractTest {
                                             .post(uri);
 
         ps.append("Request method:\tPOST\n");
-        ps.append("Request URI:\t" + uri + "\n");
+        ps.append("Request URI:\t").append(uri).append("\n");
 
         ps.append("Body:\n");
-        ps.append("HTTP/1.1 " + res.getStatusCode() + "\n");
+        ps.append("HTTP/1.1 ").append(String.valueOf(res.getStatusCode())).append("\n");
         for (Header h : res.getHeaders()) {
-            ps.append(h.getName().toString() + ": " + h.getValue().toString() + "\n");
+            ps.append(h.getName()).append(": ").append(h.getValue()).append("\n");
         }
 
-        ps.append("\n" + res.asString() + "\n");
+        ps.append("\n").append(res.asString()).append("\n");
         final String locationHeader = getLocation(res);
 
         if (res.getStatusCode() == 201) {
@@ -92,9 +90,9 @@ public class Ldpnr extends AbstractTest {
                 .get(locationHeader);
 
             for (Header h : nonr.getHeaders()) {
-                ps.append(h.getName().toString() + ": " + h.getValue().toString() + "\n");
+                ps.append(h.getName()).append(": ").append(h.getValue()).append("\n");
             }
-            ps.append("\n" + nonr.asString() + "\n");
+            ps.append("\n").append(nonr.asString()).append("\n");
             boolean header = false;
 
             for (Header h : nonr.getHeaders()) {
@@ -126,7 +124,7 @@ public class Ldpnr extends AbstractTest {
      */
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
-    public void ldpnrCreationWrongLinkType(final String uri) throws FileNotFoundException {
+    public void ldpnrCreationWrongLinkType(final String uri) {
         final TestInfo info = setupTest("3.1.2-B", "ldpnrCreationWrongLinkType",
                                         "If, in a successful resource creation request, a Link: rel=\"type\" request " +
                                         "header specifies"
@@ -145,16 +143,16 @@ public class Ldpnr extends AbstractTest {
                                             .when()
                                             .post(uri);
         ps.append("Request method:\tPOST\n");
-        ps.append("Request URI:\t" + uri + "\n");
+        ps.append("Request URI:\t").append(uri).append("\n");
         ps.append("Headers:\tAccept=*/*\n");
         ps.append("Body:\n");
 
-        ps.append("HTTP/1.1 " + res.getStatusCode() + "\n");
+        ps.append("HTTP/1.1 ").append(String.valueOf(res.getStatusCode())).append("\n");
         for (Header h : res.getHeaders()) {
-            ps.append(h.getName() + ": " + h.getValue() + "\n");
+            ps.append(h.getName()).append(": ").append(h.getValue()).append("\n");
         }
 
-        ps.append("\n" + res.asString() + "\n");
+        ps.append("\n").append(res.asString()).append("\n");
 
         if (res.getStatusCode() >= 200 && res.getStatusCode() < 300) {
             ps.append("\nExpected response with a 4xx range status code.\n");

--- a/src/main/java/org/fcrepo/spec/testsuite/report/EarlCoreReporter.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/report/EarlCoreReporter.java
@@ -50,7 +50,7 @@ public abstract class EarlCoreReporter {
     public final static Property passed = ResourceFactory.createProperty(EARL.NAMESPACE + "passed");
     public final static Property failed = ResourceFactory.createProperty(EARL.NAMESPACE + "failed");
     public final static Property untested = ResourceFactory.createProperty(EARL.NAMESPACE + "untested");
-    protected static final HashMap<String, String> prefixes = new HashMap<String, String>();
+    private static final HashMap<String, String> prefixes = new HashMap<>();
 
     static {
         prefixes.put("earl", "http://www.w3.org/ns/earl#");
@@ -60,7 +60,7 @@ public abstract class EarlCoreReporter {
         prefixes.put("ldpt", TestSuiteGlobals.ldptNamespace);
     }
 
-    protected BufferedWriter writer;
+    private BufferedWriter writer;
     protected Model model;
 
     protected void createWriter(final String directory) throws IOException {
@@ -91,7 +91,7 @@ public abstract class EarlCoreReporter {
      *
      * @param model
      */
-    public void writePrefixes(final Model model) {
+    private void writePrefixes(final Model model) {
         for (Entry<String, String> prefix : prefixes.entrySet()) {
             model.setNsPrefix(prefix.getKey(), prefix.getValue());
         }

--- a/src/main/java/org/fcrepo/spec/testsuite/report/EarlReporter.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/report/EarlReporter.java
@@ -57,13 +57,8 @@ public class EarlReporter extends EarlCoreReporter implements IReporter {
         createModel();
         try {
             createAssertions(suites);
-        } catch (NoSuchMethodException e) {
-            e.printStackTrace();
-        } catch (InstantiationException e) {
-            e.printStackTrace();
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (InvocationTargetException e) {
+        } catch (NoSuchMethodException | InstantiationException | InvocationTargetException |
+                IllegalAccessException e) {
             e.printStackTrace();
         }
         write();
@@ -95,15 +90,13 @@ public class EarlReporter extends EarlCoreReporter implements IReporter {
         }
     }
 
-    private void getResultProperties(final Map<String, String[]> tests) throws
-        InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+    private void getResultProperties(final Map<String, String[]> tests) {
         for (String[] r : tests.values()) {
             makeResultResource(r);
         }
     }
 
-    private void makeResultResource(final String[] result) throws
-        NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
+    private void makeResultResource(final String[] result) {
         final Resource assertionResource = model.createResource(null, Assertion);
 
         final Resource resultResource = model.createResource(null, TestResult);

--- a/src/main/java/org/fcrepo/spec/testsuite/report/HtmlReporter.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/report/HtmlReporter.java
@@ -27,7 +27,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -47,9 +46,8 @@ import org.testng.xml.XmlSuite;
  */
 public class HtmlReporter implements IReporter {
 
-    HashMap<String, Integer> passClasses;
-    HashMap<String, Integer> failClasses;
-    HashMap<String, Integer> skipClasses;
+    private HashMap<String, Integer> failClasses;
+    private HashMap<String, Integer> skipClasses;
     private IResultMap passedTests;
     private IResultMap failedTests;
     private IResultMap skippedTests;
@@ -83,7 +81,7 @@ public class HtmlReporter implements IReporter {
                     skippedTests = tc.getSkippedTests();
                 }
 
-                passClasses = getClasses(passedTests);
+                final HashMap<String, Integer> passClasses = getClasses(passedTests);
                 failClasses = getClasses(failedTests);
                 skipClasses = getClasses(skippedTests);
 
@@ -95,15 +93,8 @@ public class HtmlReporter implements IReporter {
                 // send html to a file
                 createWriter(html.toHtml());
             }
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (NoSuchMethodException e) {
-            e.printStackTrace();
-        } catch (InstantiationException e) {
-            e.printStackTrace();
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (InvocationTargetException e) {
+        } catch (IOException | InvocationTargetException | IllegalAccessException | InstantiationException |
+                NoSuchMethodException e) {
             e.printStackTrace();
         }
     }
@@ -115,34 +106,24 @@ public class HtmlReporter implements IReporter {
     }
 
     private void createWriter(final String output) {
-        BufferedWriter writer = null;
         final File dir = new File(TestSuiteGlobals.outputDirectory);
         dir.mkdirs();
 
         final String fileName = TestSuiteGlobals.outputName + "-execution-report.html";
         System.out.println("Writing HTML results:");
-        try {
-            final File file = new File(dir, fileName);
-            writer = new BufferedWriter(new FileWriter(file));
+        final File file = new File(dir, fileName);
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
             writer.write(output);
             System.out.println("\t" + file.getAbsolutePath());
 
         } catch (IOException e) {
-        } finally {
-            try {
-                if (writer != null) {
-                    writer.close();
-                }
-            } catch (IOException e) {
-            }
         }
     }
 
     private HashMap<String, Integer> getClasses(final IResultMap tests) {
-        final HashMap<String, Integer> classes = new HashMap<String, Integer>();
-        final Iterator<ITestResult> results = tests.getAllResults().iterator();
-        while (results.hasNext()) {
-            String name = results.next().getTestClass().getName().toString();
+        final HashMap<String, Integer> classes = new HashMap<>();
+        for (ITestResult iTestResult : tests.getAllResults()) {
+            String name = iTestResult.getTestClass().getName();
             name = name.substring(name.lastIndexOf(".") + 1);
 
             if (!classes.containsKey(name)) {
@@ -175,8 +156,7 @@ public class HtmlReporter implements IReporter {
     }
 
     private void makeMethodSummaryTable(final IResultMap passed, final IResultMap skipped, final IResultMap failed)
-        throws IOException, NoSuchMethodException, IllegalAccessException,
-        InstantiationException, InvocationTargetException {
+        throws IOException {
         html.table(class_("indented"));
         html.tr().th().content("Specification Section");
         html.th().content("Req Level");

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/HttpGet.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/HttpGet.java
@@ -17,8 +17,6 @@
  */
 package org.fcrepo.spec.testsuite.versioning;
 
-import java.io.FileNotFoundException;
-
 import org.fcrepo.spec.testsuite.AbstractTest;
 import org.testng.annotations.Parameters;
 
@@ -47,6 +45,6 @@ public class HttpGet extends AbstractTest {
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void firstTest(final String uri) throws FileNotFoundException {
+    public void firstTest(final String uri) {
     }
 }


### PR DESCRIPTION
Running tests on `master` and this PR return the same results:
::
Fedora API Specification Test Suite
Total tests run: 64, Failures: 10, Skips: 0
::

Resolves: https://github.com/fcrepo4-labs/Fedora-API-Test-Suite/issues/114