### PR TITLE
Adds complete set of  tests for section 4.3.2.

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
@@ -237,7 +237,7 @@ public class AbstractTest {
 
     private RequestSpecification createRequestAuthOnly() {
         return RestAssured.given()
-                          .auth().basic(this.username, this.password);
+                          .auth().basic(this.username, this.password).urlEncodingEnabled(false);
     }
 
     protected Response doGet(final String uri, final Header header) {

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpOptions.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpOptions.java
@@ -33,8 +33,8 @@ public class LdpcvHttpOptions extends AbstractVersioningTest {
     /**
      * Authentication
      *
-     * @param username
-     * @param password
+     * @param username The repository username
+     * @param password The repository password
      */
     @Parameters({"param2", "param3"})
     public LdpcvHttpOptions(final String username, final String password) {
@@ -44,7 +44,7 @@ public class LdpcvHttpOptions extends AbstractVersioningTest {
     /**
      * 4.3.2-A
      *
-     * @param uri
+     * @param uri The repository root URI
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
@@ -64,7 +64,7 @@ public class LdpcvHttpOptions extends AbstractVersioningTest {
     /**
      * 4.3.2-B
      *
-     * @param uri
+     * @param uri The repository root URI
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
@@ -88,7 +88,7 @@ public class LdpcvHttpOptions extends AbstractVersioningTest {
     /**
      * 4.3.2-C
      *
-     * @param uri
+     * @param uri The repository root URI
      */
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
@@ -108,7 +108,7 @@ public class LdpcvHttpOptions extends AbstractVersioningTest {
     /**
      * 4.3.2-D
      *
-     * @param uri
+     * @param uri The repository root URI
      */
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
@@ -126,14 +126,14 @@ public class LdpcvHttpOptions extends AbstractVersioningTest {
     }
 
     /**
-     * 4.3.2-D
+     * 4.3.2-E
      *
-     * @param uri
+     * @param uri The repository root URI
      */
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
     public void ldpcvMaySupportPost(final String uri) {
-        final TestInfo info = setupTest("4.3.2-D", "ldpcvMaySupportPost",
+        final TestInfo info = setupTest("4.3.2-E", "ldpcvMaySupportPost",
                                         "LDPCv (version containers) MAY support POST.",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-options",
                                         ps);
@@ -146,14 +146,14 @@ public class LdpcvHttpOptions extends AbstractVersioningTest {
     }
 
     /**
-     * 4.3.2-E
+     * 4.3.2-F
      *
-     * @param uri
+     * @param uri The repository root URI
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpcvMustReturnAcceptPostHeaderIfPostIsSupported(final String uri) {
-        final TestInfo info = setupTest("4.3.2-E", "ldpcvMustReturnAcceptPostHeaderIfPostIsSupported",
+        final TestInfo info = setupTest("4.3.2-F", "ldpcvMustReturnAcceptPostHeaderIfPostIsSupported",
                                         "If an LDPCv supports POST, the response to an OPTIONS request " +
                                         " MUST include the \"Accept-Post\" header",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-options",
@@ -172,14 +172,14 @@ public class LdpcvHttpOptions extends AbstractVersioningTest {
     }
 
     /**
-     * 4.3.2-F
+     * 4.3.2-G
      *
-     * @param uri
+     * @param uri The repository root URI
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpcvMustReturnAcceptPatchHeaderIfPatchIsSupported(final String uri) {
-        final TestInfo info = setupTest("4.3.2-F", "ldpcvMustReturnAcceptPatchHeaderIfPatchIsSupported",
+        final TestInfo info = setupTest("4.3.2-G", "ldpcvMustReturnAcceptPatchHeaderIfPatchIsSupported",
                                         "If an LDPCv supports PATCH, the response to an OPTIONS request " +
                                         " MUST include the \"Accept-Patch\" header",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-options",
@@ -191,7 +191,7 @@ public class LdpcvHttpOptions extends AbstractVersioningTest {
         final Response response = doOptions(timeMapURI.toString());
         if (hasHeaderValueInMultiValueHeader("Allow", "PATCH", response)) {
             Assert.assertTrue(getHeaders(response, "Accept-Patch").count() > 0,
-                              "If an LDPCv supports POST, the response to an OPTIONS request " +
+                              "If an LDPCv supports PATCH, the response to an OPTIONS request " +
                               " MUST include the \"Accept-Patch\" header");
 
         }

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpOptions.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpOptions.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.spec.testsuite.versioning;
+
+import java.net.URI;
+
+import io.restassured.response.Response;
+import org.fcrepo.spec.testsuite.TestInfo;
+import org.testng.Assert;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+/**
+ * @author Daniel Bernstein
+ */
+public class LdpcvHttpOptions extends AbstractVersioningTest {
+
+    /**
+     * Authentication
+     *
+     * @param username
+     * @param password
+     */
+    @Parameters({"param2", "param3"})
+    public LdpcvHttpOptions(final String username, final String password) {
+        super(username, password);
+    }
+
+    /**
+     * 4.3.2-A
+     *
+     * @param uri
+     */
+    @Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldpcvMustSupportOptions(final String uri) {
+        final TestInfo info = setupTest("4.3.2-A", "ldpcvMustSupportOptions",
+                                        "LDPCv (version containers) MUST support OPTIONS.",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-options",
+                                        ps);
+
+        //create ldprv
+        final Response createResponse = createVersionedResource(uri, info);
+        final URI timeMapURI = getTimeMapUri(createResponse);
+        final Response response = doGet(timeMapURI.toString());
+        confirmPresenceOfHeaderValueInMultiValueHeader("Allow", "OPTIONS", response);
+    }
+
+    /**
+     * 4.3.2-B
+     *
+     * @param uri
+     */
+    @Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldpcvOptionsMustAllowHeadGetOptions(final String uri) {
+        final TestInfo info = setupTest("4.3.2-B", "ldpcvOptionsMustAllowHeadGetOptions",
+                                        "LDPCv's response to an OPTIONS request MUST include \"Allow: GET, " +
+                                        "HEAD, OPTIONS\" per LDP",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-options",
+                                        ps);
+
+        //create ldprv
+        final Response createResponse = createVersionedResource(uri, info);
+        final URI timeMapURI = getTimeMapUri(createResponse);
+        final Response response = doOptions(timeMapURI.toString());
+        confirmPresenceOfHeaderValueInMultiValueHeader("Allow", "GET", response);
+        confirmPresenceOfHeaderValueInMultiValueHeader("Allow", "HEAD", response);
+        confirmPresenceOfHeaderValueInMultiValueHeader("Allow", "OPTIONS", response);
+
+    }
+
+    /**
+     * 4.3.2-C
+     *
+     * @param uri
+     */
+    @Test(groups = {"MAY"})
+    @Parameters({"param1"})
+    public void ldpcvMaySupportDelete(final String uri) {
+        final TestInfo info = setupTest("4.3.2-C", "ldpcvMaySupportDelete",
+                                        "LDPCv (version containers) MAY support DELETE.",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-options",
+                                        ps);
+
+        //create ldprv
+        final Response createResponse = createVersionedResource(uri, info);
+        final URI timeMapURI = getTimeMapUri(createResponse);
+        final Response response = doOptions(timeMapURI.toString());
+        confirmPresenceOfHeaderValueInMultiValueHeader("Allow", "DELETE", response);
+    }
+
+    /**
+     * 4.3.2-D
+     *
+     * @param uri
+     */
+    @Test(groups = {"MAY"})
+    @Parameters({"param1"})
+    public void ldpcvMaySupportPatch(final String uri) {
+        final TestInfo info = setupTest("4.3.2-D", "ldpcvMaySupportPatch",
+                                        "LDPCv (version containers) MAY support PATCH.",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-options",
+                                        ps);
+
+        //create ldprv
+        final Response createResponse = createVersionedResource(uri, info);
+        final URI timeMapURI = getTimeMapUri(createResponse);
+        final Response response = doOptions(timeMapURI.toString());
+        confirmPresenceOfHeaderValueInMultiValueHeader("Allow", "PATCH", response);
+    }
+
+    /**
+     * 4.3.2-D
+     *
+     * @param uri
+     */
+    @Test(groups = {"MAY"})
+    @Parameters({"param1"})
+    public void ldpcvMaySupportPost(final String uri) {
+        final TestInfo info = setupTest("4.3.2-D", "ldpcvMaySupportPost",
+                                        "LDPCv (version containers) MAY support POST.",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-options",
+                                        ps);
+
+        //create ldprv
+        final Response createResponse = createVersionedResource(uri, info);
+        final URI timeMapURI = getTimeMapUri(createResponse);
+        final Response response = doOptions(timeMapURI.toString());
+        confirmPresenceOfHeaderValueInMultiValueHeader("Allow", "POST", response);
+    }
+
+    /**
+     * 4.3.2-E
+     *
+     * @param uri
+     */
+    @Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldpcvMustReturnAcceptPostHeaderIfPostIsSupported(final String uri) {
+        final TestInfo info = setupTest("4.3.2-E", "ldpcvMustReturnAcceptPostHeaderIfPostIsSupported",
+                                        "If an LDPCv supports POST, the response to an OPTIONS request " +
+                                        " MUST include the \"Accept-Post\" header",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-options",
+                                        ps);
+
+        //create ldprv
+        final Response createResponse = createVersionedResource(uri, info);
+        final URI timeMapURI = getTimeMapUri(createResponse);
+        final Response response = doOptions(timeMapURI.toString());
+        if (hasHeaderValueInMultiValueHeader("Allow", "POST", response)) {
+            Assert.assertTrue(getHeaders(response, "Accept-Post").count() > 0,
+                              "If an LDPCv supports POST, the response to an OPTIONS request " +
+                              " MUST include the \"Accept-Post\" header");
+
+        }
+    }
+
+    /**
+     * 4.3.2-F
+     *
+     * @param uri
+     */
+    @Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldpcvMustReturnAcceptPatchHeaderIfPatchIsSupported(final String uri) {
+        final TestInfo info = setupTest("4.3.2-F", "ldpcvMustReturnAcceptPatchHeaderIfPatchIsSupported",
+                                        "If an LDPCv supports PATCH, the response to an OPTIONS request " +
+                                        " MUST include the \"Accept-Patch\" header",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-options",
+                                        ps);
+
+        //create ldprv
+        final Response createResponse = createVersionedResource(uri, info);
+        final URI timeMapURI = getTimeMapUri(createResponse);
+        final Response response = doOptions(timeMapURI.toString());
+        if (hasHeaderValueInMultiValueHeader("Allow", "PATCH", response)) {
+            Assert.assertTrue(getHeaders(response, "Accept-Patch").count() > 0,
+                              "If an LDPCv supports POST, the response to an OPTIONS request " +
+                              " MUST include the \"Accept-Patch\" header");
+
+        }
+    }
+}

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprvHttpGet.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprvHttpGet.java
@@ -20,7 +20,6 @@ package org.fcrepo.spec.testsuite.versioning;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 import static org.fcrepo.spec.testsuite.Constants.ORIGINAL_RESOURCE_LINK_HEADER;
-import static org.fcrepo.spec.testsuite.Constants.SLUG;
 import static org.fcrepo.spec.testsuite.Constants.TIME_GATE_LINK_HEADER;
 
 import java.net.URI;
@@ -28,11 +27,9 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
-import java.util.stream.Stream;
 import javax.ws.rs.core.Link;
 
 import io.restassured.http.Header;
-import io.restassured.http.Headers;
 import io.restassured.response.Response;
 import org.fcrepo.spec.testsuite.TestInfo;
 import org.testng.Assert;
@@ -265,13 +262,6 @@ public class LdprvHttpGet extends AbstractVersioningTest {
         return FMT.format(ISO_INSTANT.parse(isoDateString, Instant::from));
     }
 
-    private Response createVersionedResource(final String uri, final TestInfo info) {
-        final Headers headers = new Headers(
-                new Header("Link", ORIGINAL_RESOURCE_LINK_HEADER),
-                new Header(SLUG, info.getId()));
-        return doPost(uri, headers);
-    }
-
     private void confirmPresenceOfTimeGateLink(final Response response) {
         confirmPresenceOfRelType(response, "timegate");
     }
@@ -299,29 +289,8 @@ public class LdprvHttpGet extends AbstractVersioningTest {
         return getLinksOfRelTypeAsUris(response, "timegate").findFirst().get();
     }
 
-    private URI getTimeMapUri(final Response response) {
-        return getLinksOfRelTypeAsUris(response, "timemap").findFirst().get();
-    }
 
     private URI getOriginalUri(final Response response) {
         return getLinksOfRelTypeAsUris(response, "original").findFirst().get();
-    }
-
-    private Stream<URI> getLinksOfRelTypeAsUris(final Response response, final String relType) {
-        return getLinksOfRelType(response, relType)
-            .map(link -> link.getUri());
-    }
-
-    private Stream<Header> getHeaders(final Response response, final String headerName) {
-        return response.getHeaders()
-                       .getList(headerName)
-                       .stream();
-    }
-
-    private Stream<Link> getLinksOfRelType(final Response response, final String relType) {
-        return getHeaders(response, "Link")
-            .flatMap(header ->  Arrays.stream(header.getValue().split(",")).map(linkStr -> Link.valueOf(linkStr)))
-            .filter(link -> link.getRel().equalsIgnoreCase(relType));
-
     }
 }

--- a/src/main/resources/testng.xml
+++ b/src/main/resources/testng.xml
@@ -56,7 +56,7 @@
       <class name="org.fcrepo.spec.testsuite.crud.HttpDelete"/>
       <class name="org.fcrepo.spec.testsuite.crud.ExternalBinaryContent"/>
       <class name="org.fcrepo.spec.testsuite.versioning.LdprvHttpGet"/>
-
+      <class name="org.fcrepo.spec.testsuite.versioning.LdpcvHttpOptions"/>
     </classes>
 
   </test>


### PR DESCRIPTION
Note: the following tests are expected to fail:

4.3.2-D | MAY |  LDPCv (version containers) MAY support PATCH.
4.3.2-E | MUST | If an LDPCv supports POST, the response to an OPTIONS request MUST include the "Accept-Post" header

