### PR TITLE
Stubs out rest of the versioning tests.

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpDelete.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpDelete.java
@@ -41,7 +41,7 @@ public class LdpcvHttpDelete extends AbstractVersioningTest {
     /**
      * 4.3.6
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"SHOULD"})
     @Parameters({"param1"})

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpDelete.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpDelete.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.spec.testsuite.versioning;
+
+import org.fcrepo.spec.testsuite.TestInfo;
+import org.testng.annotations.Parameters;
+
+/**
+ * Tests for DELETE requests on LDP Version Container Resources
+ *
+ * @author Daniel Bernstein
+ */
+public class LdpcvHttpDelete extends AbstractVersioningTest {
+
+    /**
+     * Authentication
+     *
+     * @param username The repository username
+     * @param password The repository password
+     */
+    @Parameters({"param2", "param3"})
+    public LdpcvHttpDelete(final String username, final String password) {
+        super(username, password);
+    }
+
+    /**
+     * 4.3.6
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"SHOULD"})
+    @Parameters({"param1"})
+    public void ldpcvThatAdvertisesDeleteShouldRemoveContainerAndMementos(final String uri) {
+        final TestInfo info = setupTest("4.3.6", "ldpcvThatAdvertisesDeleteShouldRemoveContainerAndMementos",
+                                        "An implementation that does support DELETE should do so by both " +
+                                        "removing the LDPCv and removing the versioning interaction model from the " +
+                                        "original LDPRv.",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-delete",
+                                        ps);
+
+    }
+
+}

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpGet.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpGet.java
@@ -41,7 +41,7 @@ public class LdpcvHttpGet extends AbstractVersioningTest {
     /**
      * 4.3.1-A
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})
@@ -59,7 +59,7 @@ public class LdpcvHttpGet extends AbstractVersioningTest {
     /**
      * 4.3.1-B
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})
@@ -77,13 +77,13 @@ public class LdpcvHttpGet extends AbstractVersioningTest {
     /**
      * 4.3.1-C
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpcvMustRespondToGetWithApplicationLinkAcceptHeader(final String uri) {
         final TestInfo info = setupTest("4.3.1-C", "ldpcvMustRespondToGetWithApplicationLinkAcceptHeader",
-                                        "An LDPCvmust respond to GET Accept: application/link-format as " +
+                                        "An LDPCv must respond to GET Accept: application/link-format as " +
                                         "indicated in [ RFC7089 ] section 5 and specified in [ RFC6690 ] section 7.3.",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-get",
                                         ps);
@@ -94,7 +94,7 @@ public class LdpcvHttpGet extends AbstractVersioningTest {
     /**
      * 4.3.1-D
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})
@@ -110,7 +110,7 @@ public class LdpcvHttpGet extends AbstractVersioningTest {
     /**
      * 4.3.1-E
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})
@@ -127,7 +127,7 @@ public class LdpcvHttpGet extends AbstractVersioningTest {
     /**
      * 4.3.1-F
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})
@@ -144,7 +144,7 @@ public class LdpcvHttpGet extends AbstractVersioningTest {
     /**
      * 4.3.1-G
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpGet.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpGet.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.spec.testsuite.versioning;
+
+import org.fcrepo.spec.testsuite.TestInfo;
+import org.testng.annotations.Parameters;
+
+/**
+ * Tests for GET requests on LDP Version Container Resources
+ *
+ * @author Daniel Bernstein
+ */
+public class LdpcvHttpGet extends AbstractVersioningTest {
+
+    /**
+     * Authentication
+     *
+     * @param username The repository username
+     * @param password The repository password
+     */
+    @Parameters({"param2", "param3"})
+    public LdpcvHttpGet(final String username, final String password) {
+        super(username, password);
+    }
+
+    /**
+     * 4.3.1-A
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldpcvMustSupportGet(final String uri) {
+        final TestInfo info = setupTest("4.3.1-A", "ldpcvMustSupportGet",
+                                        "LDPCv must support GET, as is the case for any LDPR",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-get",
+                                        ps);
+
+        //create a versioned resource
+        //get the timemap
+        //perform a GET and verify that it is successful.
+    }
+
+    /**
+     * 4.3.1-B
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldpcvMustHaveTimeMapLinkHeader(final String uri) {
+        final TestInfo info = setupTest("4.3.1-B", "ldpcvMustHaveTimeMapLinkHeader",
+                                        "LDPCv contain TimeMap type link header.",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-get",
+                                        ps);
+
+        //create a versioned resource
+        //get the timemap
+        //perform a GET and verify it has the proper header.
+    }
+
+    /**
+     * 4.3.1-C
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldpcvMustRespondToGetWithApplicationLinkAcceptHeader(final String uri) {
+        final TestInfo info = setupTest("4.3.1-C", "ldpcvMustRespondToGetWithApplicationLinkAcceptHeader",
+                                        "An LDPCvmust respond to GET Accept: application/link-format as " +
+                                        "indicated in [ RFC7089 ] section 5 and specified in [ RFC6690 ] section 7.3.",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-get",
+                                        ps);
+
+
+    }
+
+    /**
+     * 4.3.1-D
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void lpcvMustIncludeAllowHeader(final String uri) {
+        final TestInfo info = setupTest("4.3.1-D", "lpcvMustIncludeAllowHeader",
+                                        "LDPCv resources must include the Allow header",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-get",
+                                        ps);
+
+
+    }
+
+    /**
+     * 4.3.1-E
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldpcvMustIncludeAcceptPostIfPostAllowed(final String uri) {
+        final TestInfo info = setupTest("4.3.1-E", "ldpcvMustIncludeAcceptPostIfPostAllowed",
+                                        "If an LDPCv supports POST, then it must include the Accept-Post header",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-get",
+                                        ps);
+        //check if LDPCv allows "POST"
+        //If so,  check for presence of Accept-Post header.
+
+    }
+
+    /**
+     * 4.3.1-F
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldpcvMustIncludeAcceptPatchIfPatchAllowed(final String uri) {
+        final TestInfo info = setupTest("4.3.1-F", "ldpcvMustIncludeAcceptPatchIfPatchAllowed",
+                                        "If an LDPCv supports PATCH, then it must include the Accept-Patch header",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-get",
+                                        ps);
+        //check if LDPCv allows "PATCH"
+        //If so,  check for presence of Accept-Patch header.
+
+    }
+
+    /**
+     * 4.3.1-G
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldpcvMustHaveContainerLinkHeader(final String uri) {
+        final TestInfo info = setupTest("4.3.1-G", "ldpcvMustHaveContainerLinkHeader",
+                                        "An LDPCv, being a container must have a \"Link: <http://www" +
+                                        ".w3.org/ns/ldp#Container>;rel=\"type\"\"",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-get",
+                                        ps);
+
+        //create a versioned resource
+        //get the timemap
+        //perform a GET and verify it has the proper header.
+    }
+
+
+
+}
+

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpPost.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpPost.java
@@ -41,15 +41,14 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
     /**
      * 4.3.3.1-A
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
-    //@Test(groups = {"MUST"})
+    //@Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void ldpcvOfLdprsMustSupportPostWithoutMementoDatetimeHeader(final String uri) {
         final TestInfo info = setupTest("4.3.3.1-A", "ldpcvOfLdprsMustSupportPostWithoutMementoDatetimeHeader",
                                         "If an LDPCv of an LDP-RS supports POST, a POST request that does not contain" +
-                                        " a " +
-                                        "Memento-Datetime header should be understood to create a new LDPRm " +
+                                        " a Memento-Datetime header should be understood to create a new LDPRm " +
                                         "contained by the LDPCv, reflecting the state of the LDPRv at the time of " +
                                         "the POST. ",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-post",
@@ -60,15 +59,14 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
     /**
      * 4.3.3.1-B
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
-    //@Test(groups = {"MUST"})
+    //@Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void ldpcvOfLdpnrsMustSupportPostWithoutMementoDatetimeHeader(final String uri) {
         final TestInfo info = setupTest("4.3.3.1-B", "ldpcvOfLdpnrsMustSupportPostWithoutMementoDatetimeHeader",
                                         "If an LDPCv of an LDP-NR supports POST, a POST request that does not contain" +
-                                        " a " +
-                                        "Memento-Datetime header should be understood to create a new LDPRm " +
+                                        " a Memento-Datetime header should be understood to create a new LDPRm " +
                                         "contained by the LDPCv, reflecting the state of the LDPRv at the time of " +
                                         "the POST. ",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-post",
@@ -80,7 +78,7 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
     /**
      * 4.3.3.1-C
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})
@@ -97,7 +95,7 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
     /**
      * 4.3.3.1-D
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})
@@ -114,7 +112,7 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
     /**
      * 4.3.3.1-E
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     // @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
@@ -131,7 +129,7 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
     /**
      * 4.3.3.1-F
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"SHOULD"})
     @Parameters({"param1"})
@@ -148,7 +146,7 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
     /**
      * 4.3.3.2
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})
@@ -165,7 +163,7 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
     /**
      * 4.3.4
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MAY"})
     @Parameters({"param1"})
@@ -180,7 +178,7 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
     /**
      * 4.3.5
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MAY"})
     @Parameters({"param1"})

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpPost.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpPost.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.spec.testsuite.versioning;
+
+import org.fcrepo.spec.testsuite.TestInfo;
+import org.testng.annotations.Parameters;
+
+/**
+ * Tests for POST requests on LDP Version Container Resources
+ *
+ * @author Daniel Bernstein
+ */
+public class LdpcvHttpPost extends AbstractVersioningTest {
+
+    /**
+     * Authentication
+     *
+     * @param username The repository username
+     * @param password The repository password
+     */
+    @Parameters({"param2", "param3"})
+    public LdpcvHttpPost(final String username, final String password) {
+        super(username, password);
+    }
+
+    /**
+     * 4.3.3.1-A
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldpcvOfLdprsMustSupportPostWithoutMementoDatetimeHeader(final String uri) {
+        final TestInfo info = setupTest("4.3.3.1-A", "ldpcvOfLdprsMustSupportPostWithoutMementoDatetimeHeader",
+                                        "If an LDPCv of an LDP-RS supports POST, a POST request that does not contain" +
+                                        " a " +
+                                        "Memento-Datetime header should be understood to create a new LDPRm " +
+                                        "contained by the LDPCv, reflecting the state of the LDPRv at the time of " +
+                                        "the POST. ",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-post",
+                                        ps);
+
+    }
+
+    /**
+     * 4.3.3.1-B
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldpcvOfLdpnrsMustSupportPostWithoutMementoDatetimeHeader(final String uri) {
+        final TestInfo info = setupTest("4.3.3.1-B", "ldpcvOfLdpnrsMustSupportPostWithoutMementoDatetimeHeader",
+                                        "If an LDPCv of an LDP-NR supports POST, a POST request that does not contain" +
+                                        " a " +
+                                        "Memento-Datetime header should be understood to create a new LDPRm " +
+                                        "contained by the LDPCv, reflecting the state of the LDPRv at the time of " +
+                                        "the POST. ",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-post",
+                                        ps);
+
+        //same as previous test but with LDP-NR
+    }
+
+    /**
+     * 4.3.3.1-C
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void postToldpcvOfLdprsWithoutMementoDatetimeMustIgnoreBody(final String uri) {
+        final TestInfo info = setupTest("4.3.3.1-C", "postToldpcvOfLdprsWithoutMementoDatetimeMustIgnoreBody",
+                                        "If an LDPCv of an LDP-RS supports POST, a POST request that does not contain" +
+                                        " a " +
+                                        "Memento-Datetime header MUST ignore any request body.",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-post",
+                                        ps);
+
+    }
+
+    /**
+     * 4.3.3.1-D
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void postToldpcvOfLdpnrWithoutMementoDatetimeMustIgnoreBody(final String uri) {
+        final TestInfo info = setupTest("4.3.3.1-D", "postToldpcvOfLdpnrWithoutMementoDatetimeMustIgnoreBody",
+                                        "If an LDPCv of an LDP-NR supports POST, a POST request that does not contain" +
+                                        " a " +
+                                        "Memento-Datetime header MUST ignore any request body.",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-post",
+                                        ps);
+        //same as previous but with LDP-NR
+    }
+
+    /**
+     * 4.3.3.1-E
+     *
+     * @param uri The repostory root URI
+     */
+    // @Test(groups = {"SHOULD"})
+    @Parameters({"param1"})
+    public void postToldpcvOfLdprWithMementoDatetimeShouldCreateNewResource(final String uri) {
+        final TestInfo info = setupTest("4.3.3.1-E", "postToldpcvOfLdprWithMementoDatetimeShouldCreateNewResource",
+                                        "If an LDPCv supports POST, a POST with a Memento-Datetime header " +
+                                        "should be understood to create a new LDPRm contained by the LDPCv, with the " +
+                                        "state given in the request body.",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-post",
+                                        ps);
+
+    }
+
+    /**
+     * 4.3.3.1-F
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"SHOULD"})
+    @Parameters({"param1"})
+    public void mementoDatetimeHeaderShouldMatchThatUsedWhenMementoCreated(final String uri) {
+        final TestInfo info = setupTest("4.3.3.1-F", "mementoDatetimeHeaderShouldMatchThatUsedWhenMementoCreated",
+                                        " If an LDPCv supports POST, a POST with a Memento-Datetime header " +
+                                        "should be understood to create a new LDPRm contained by the LDPCv, with the " +
+                                        "datetime given in the Memento-Datetime request header.",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-post",
+                                        ps);
+
+    }
+
+    /**
+     * 4.3.3.2
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldpcvDoesNotSupportPost(final String uri) {
+        final TestInfo info = setupTest("4.3.3.2", "ldpcvDoesNotSupportPost",
+                                        "If an implementation does not support one or both of POST cases " +
+                                        "above, it must respond to such requests with a 4xx range status code and a " +
+                                        "link to an appropriate constraints document",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-post",
+                                        ps);
+
+    }
+
+    /**
+     * 4.3.4
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MAY"})
+    @Parameters({"param1"})
+    public void ldpcvMayDisallowPut(final String uri) {
+        final TestInfo info = setupTest("4.3.4", "ldpcvMayDisallowPut",
+                                        "Implementations MAY disallow PUT.",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-put",
+                                        ps);
+
+    }
+
+    /**
+     * 4.3.5
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MAY"})
+    @Parameters({"param1"})
+    public void ldpcvMayDisallowPatch(final String uri) {
+        final TestInfo info = setupTest("4.3.5", "ldpcvMayDisallowPatch",
+                                        "Implementations MAY disallow PATCH",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldpcv-patch",
+                                        ps);
+
+    }
+
+}
+

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprmHttpDelete.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprmHttpDelete.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.spec.testsuite.versioning;
+
+import org.fcrepo.spec.testsuite.TestInfo;
+import org.testng.annotations.Parameters;
+
+/**
+ * Tests for DELETE requests on LDP Memento Resources
+ *
+ * @author Daniel Bernstein
+ */
+public class LdprmHttpDelete extends AbstractVersioningTest {
+
+    /**
+     * Authentication
+     *
+     * @param username The repository username
+     * @param password The repository password
+     */
+    @Parameters({"param2", "param3"})
+    public LdprmHttpDelete(final String username, final String password) {
+        super(username, password);
+    }
+
+    /**
+     * 4.2.6
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldprmMustSupportDeleteIfAdvertised(final String uri) {
+        final TestInfo info = setupTest("4.2.6", "ldprmMustSupportDeleteIfAdvertised",
+                                        "LDPRm resources must support DELETE if DELETE is advertised in OPTIONS",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldprm-delete",
+                                        ps);
+
+        //create an LDPRm
+        //check if LDPRm supports DELETE and if so perform DELETE
+        //verify that the DELETE is reflected in a 404 on a subsequent GET
+        //and that the LDPCv no longer has a reference to it.
+
+    }
+
+
+}
+

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprmHttpDelete.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprmHttpDelete.java
@@ -41,7 +41,7 @@ public class LdprmHttpDelete extends AbstractVersioningTest {
     /**
      * 4.2.6
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprmHttpGet.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprmHttpGet.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.spec.testsuite.versioning;
+
+import org.fcrepo.spec.testsuite.TestInfo;
+import org.testng.annotations.Parameters;
+
+/**
+ * Tests for GET requests on LDP Memento Resources
+ *
+ * @author Daniel Bernstein
+ */
+public class LdprmHttpGet extends AbstractVersioningTest {
+
+    /**
+     * Authentication
+     *
+     * @param username The repository username
+     * @param password The repository password
+     */
+    @Parameters({"param2", "param3"})
+    public LdprmHttpGet(final String username, final String password) {
+        super(username, password);
+    }
+
+    /**
+     * 4.2.1-A
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldprmMustSupportGet(final String uri) {
+        final TestInfo info = setupTest("4.2.1-A", "ldprmMustSupportGet",
+                                        "LDPR mementos must support GET",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldprm-get",
+                                        ps);
+
+        //create an LDPRm
+        //verify that a subsequent GET returns 200.
+
+    }
+
+    /**
+     * 4.2.1-B
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldpnrmMustSupportGet(final String uri) {
+        final TestInfo info = setupTest("4.2.1-A", "ldpnrmMustSupportGet",
+                                        "LDP-NR mementos must support GET",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldprm-get",
+                                        ps);
+
+        //create an LDP-NR memento
+        //verify that a subsequent GET returns 200.
+
+    }
+
+    /**
+     * 4.2.1-C
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldprmMustHaveCorrectTimeGate(final String uri) {
+        final TestInfo info = setupTest("4.2.1-C", "ldprmMustHaveCorrectTimeGate",
+                                        "TimeGate  for an  LDP-RS memento  is the original versioned LDP-RS",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldprm-get",
+                                        ps);
+
+        //create an LDPR memento
+        //verify that the timegate matches that of the original LDPR
+
+    }
+
+    /**
+     * 4.2.1-D
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldpnrmMustHaveCorrectTimeGate(final String uri) {
+        final TestInfo info = setupTest("4.2.1-C", "ldpnrmMustHaveCorrectTimeGate",
+                                        "TimeGate  for an  LDP-NR memento  is the original versioned LDP-NR",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldprm-get",
+                                        ps);
+
+        //create an LDP-NR memento
+        //verify that the timegate matches that of the original LDP-NR
+
+    }
+
+    /**
+     * 4.2.1-E
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldprmMustHaveMementoLinkHeader(final String uri) {
+        final TestInfo info = setupTest("4.2.1-E", "ldprmMustHaveMementoLinkHeader",
+                                        "Any response to a GET request on an LDP-RS Memento must include a " +
+                                        "<http://mementoweb.org/ns#Memento>; rel=\"type\" link in the Link header",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldprm-get",
+                                        ps);
+
+        //create an LDP-NR memento
+        //verify that the appropriate link header is present
+
+    }
+
+    /**
+     * 4.2.1-F
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldpnrmMustHaveMementoLinkHeader(final String uri) {
+        final TestInfo info = setupTest("4.2.1-F", "ldpnrmMustHaveMementoLinkHeader",
+                                        "Any response to a GET request on an LDP-NR Memento must include a " +
+                                        "<http://mementoweb.org/ns#Memento>; rel=\"type\" link in the Link header",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldprm-get",
+                                        ps);
+
+        //create an LDP-NR memento
+        //verify that the appropriate link header is present
+
+    }
+}
+

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprmHttpGet.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprmHttpGet.java
@@ -41,7 +41,7 @@ public class LdprmHttpGet extends AbstractVersioningTest {
     /**
      * 4.2.1-A
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})
@@ -59,12 +59,12 @@ public class LdprmHttpGet extends AbstractVersioningTest {
     /**
      * 4.2.1-B
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpnrmMustSupportGet(final String uri) {
-        final TestInfo info = setupTest("4.2.1-A", "ldpnrmMustSupportGet",
+        final TestInfo info = setupTest("4.2.1-B", "ldpnrmMustSupportGet",
                                         "LDP-NR mementos must support GET",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprm-get",
                                         ps);
@@ -77,7 +77,7 @@ public class LdprmHttpGet extends AbstractVersioningTest {
     /**
      * 4.2.1-C
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})
@@ -95,12 +95,12 @@ public class LdprmHttpGet extends AbstractVersioningTest {
     /**
      * 4.2.1-D
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpnrmMustHaveCorrectTimeGate(final String uri) {
-        final TestInfo info = setupTest("4.2.1-C", "ldpnrmMustHaveCorrectTimeGate",
+        final TestInfo info = setupTest("4.2.1-D", "ldpnrmMustHaveCorrectTimeGate",
                                         "TimeGate  for an  LDP-NR memento  is the original versioned LDP-NR",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprm-get",
                                         ps);
@@ -113,7 +113,7 @@ public class LdprmHttpGet extends AbstractVersioningTest {
     /**
      * 4.2.1-E
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})
@@ -132,7 +132,7 @@ public class LdprmHttpGet extends AbstractVersioningTest {
     /**
      * 4.2.1-F
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprmHttpOptions.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprmHttpOptions.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.spec.testsuite.versioning;
+
+import org.fcrepo.spec.testsuite.TestInfo;
+import org.testng.annotations.Parameters;
+
+/**
+ * Tests for OPTIONS requests on LDP Memento Resources
+ *
+ * @author Daniel Bernstein
+ */
+public class LdprmHttpOptions extends AbstractVersioningTest {
+
+    /**
+     * Authentication
+     *
+     * @param username The repository username
+     * @param password The repository password
+     */
+    @Parameters({"param2", "param3"})
+    public LdprmHttpOptions(final String username, final String password) {
+        super(username, password);
+    }
+
+    /**
+     * 4.2.2-A
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldprmMustSupportOptions(final String uri) {
+        final TestInfo info = setupTest("4.2.2-A", "ldprmMustSupportOptions",
+                                        "LDPRm resources must support OPTIONS",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldprm-options",
+                                        ps);
+
+        //create an LDPRm
+        //verify that a subsequent GET returns OPTIONS in "Allow" header.
+
+    }
+
+    /**
+     * 4.2.2-B
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldprmOptionsMustSupportGetHeadAndOptions(final String uri) {
+        final TestInfo info = setupTest("4.2.2-B", "ldprmOptionsMustSupportGetHeadAndOptions",
+                                        "A response to an OPTIONS request must include Allow: GET, HEAD, OPTIONS",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldprm-options",
+                                        ps);
+
+        //create an LDPRm
+        //verify that a subsequent OPTIONS return "GET", "HEAD", and "OPTIONS" in "Allow" header.
+
+    }
+
+    /**
+     * 4.2.2-C
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MAY"})
+    @Parameters({"param1"})
+    public void ldprmOptionsMaySupportDelete(final String uri) {
+        final TestInfo info = setupTest("4.2.2-C", "ldprmOptionsMaySupportDelete",
+                                        "A response to an OPTIONS request may include Allow: DELETE",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldprm-options",
+                                        ps);
+
+        //create an LDPRm
+        //verify that a subsequent OPTIONS return "DELETE"
+    }
+
+    /**
+     * 4.2.3
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldprmMustNotSupportPost(final String uri) {
+        final TestInfo info = setupTest("4.2.3", "ldprmMustNotSupportPost",
+                                        "An LDPRm must not support POST",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldprm-post",
+                                        ps);
+
+        //create an LDPRm
+        //verify that a subsequent OPTIONS does not return POST
+        //verify that issuing a POST returns a 405 (method not allowed).
+    }
+
+    /**
+     * 4.2.4
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldprmMustNotSupportPut(final String uri) {
+        final TestInfo info = setupTest("4.2.4", "ldprmMustNotSupportPut",
+                                        "An LDPRm must not support PUT",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldprm-put",
+                                        ps);
+
+        //create an LDPRm
+        //verify that a subsequent OPTIONS does not return PUT
+        //verify that issuing a PUT returns a 405 (method not allowed).
+    }
+
+    /**
+     * 4.2.5
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldprmMustNotSupportPatch(final String uri) {
+        final TestInfo info = setupTest("4.2.5", "ldprmMustNotSupportPatch",
+                                        "An LDPRm must not support PATCH",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldprm-patch",
+                                        ps);
+
+        //create an LDPRm
+        //verify that a subsequent OPTIONS does not return PATCH
+        //verify that issuing a PATCH returns a 405 (method not allowed).
+    }
+
+}
+

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprmHttpOptions.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprmHttpOptions.java
@@ -41,7 +41,7 @@ public class LdprmHttpOptions extends AbstractVersioningTest {
     /**
      * 4.2.2-A
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})
@@ -59,7 +59,7 @@ public class LdprmHttpOptions extends AbstractVersioningTest {
     /**
      * 4.2.2-B
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})
@@ -77,7 +77,7 @@ public class LdprmHttpOptions extends AbstractVersioningTest {
     /**
      * 4.2.2-C
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MAY"})
     @Parameters({"param1"})
@@ -94,7 +94,7 @@ public class LdprmHttpOptions extends AbstractVersioningTest {
     /**
      * 4.2.3
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})
@@ -112,7 +112,7 @@ public class LdprmHttpOptions extends AbstractVersioningTest {
     /**
      * 4.2.4
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})
@@ -130,7 +130,7 @@ public class LdprmHttpOptions extends AbstractVersioningTest {
     /**
      * 4.2.5
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprvHttpPut.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprvHttpPut.java
@@ -39,7 +39,7 @@ public class LdprvHttpPut extends AbstractVersioningTest {
     /**
      * 4.1.2-A
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})
@@ -57,7 +57,7 @@ public class LdprvHttpPut extends AbstractVersioningTest {
     /**
      * 4.1.2-B
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})
@@ -76,7 +76,7 @@ public class LdprvHttpPut extends AbstractVersioningTest {
     /**
      * 4.1.2-C
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})
@@ -94,7 +94,7 @@ public class LdprvHttpPut extends AbstractVersioningTest {
     /**
      * 4.1.2-D
      *
-     * @param uri The repostory root URI
+     * @param uri The repository root URI
      */
     //@Test(groups = {"MUST"})
     @Parameters({"param1"})

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprvHttpPut.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprvHttpPut.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.spec.testsuite.versioning;
+
+import org.fcrepo.spec.testsuite.TestInfo;
+import org.testng.annotations.Parameters;
+
+/**
+ * @author Daniel Bernstein
+ */
+public class LdprvHttpPut extends AbstractVersioningTest {
+
+    /**
+     * Authentication
+     *
+     * @param username The repository username
+     * @param password The repository password
+     */
+    @Parameters({"param2", "param3"})
+    public LdprvHttpPut(final String username, final String password) {
+        super(username, password);
+    }
+
+    /**
+     * 4.1.2-A
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldprvMustSupportPUT(final String uri) {
+        final TestInfo info = setupTest("4.1.2-A", "ldprvMustSupportPUT",
+                                        "Must support PUT for creating new LDPRv",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldprv-put",
+                                        ps);
+
+        //create an LDPRv using a put
+        //verify that it is a TimeGate and has a TimeMap
+
+    }
+
+    /**
+     * 4.1.2-B
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldprvMustSupportPUTForExistingResources(final String uri) {
+        final TestInfo info = setupTest("4.1.2-B", "ldprvMustSupportPUTForExistingResources",
+                                        "Must support PUT for updating existing LDPRvs",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldprv-put",
+                                        ps);
+        //create an LDPRv
+        //verify that "Allow: PUT" header is present
+        //update an existing LDPRv using a put
+        //verify that it is a TimeGate and has a TimeMap
+
+    }
+
+    /**
+     * 4.1.2-C
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldpnrvMustSupportPUT(final String uri) {
+        final TestInfo info = setupTest("4.1.2-C", "ldpnrvMustSupportPUT",
+                                        "Must support PUT for creating new LDPNRv",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldprv-put",
+                                        ps);
+
+        //create an LDPNRv using a put
+        //verify that it is a TimeGate and has a TimeMap
+
+    }
+
+    /**
+     * 4.1.2-D
+     *
+     * @param uri The repostory root URI
+     */
+    //@Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void ldpnrvMustSupportPUTForExistingResources(final String uri) {
+        final TestInfo info = setupTest("4.1.2-D", "ldpnrvMustSupportPUTForExistingResources",
+                                        "Must support PUT for updating existing  LDPNRvs",
+                                        "https://fcrepo.github.io/fcrepo-specification/#ldprv-put",
+                                        ps);
+        //create an LDPNRv
+        //verify that "Allow: PUT" header is present
+        //update an existing LDPNRv using a put
+        //verify that it is a TimeGate and has a TimeMap
+
+    }
+  }

--- a/src/main/resources/testng.xml
+++ b/src/main/resources/testng.xml
@@ -56,7 +56,15 @@
       <class name="org.fcrepo.spec.testsuite.crud.HttpDelete"/>
       <class name="org.fcrepo.spec.testsuite.crud.ExternalBinaryContent"/>
       <class name="org.fcrepo.spec.testsuite.versioning.LdprvHttpGet"/>
+      <class name="org.fcrepo.spec.testsuite.versioning.LdprvHttpPut"/>
+      <class name="org.fcrepo.spec.testsuite.versioning.LdprmHttpGet"/>
+      <class name="org.fcrepo.spec.testsuite.versioning.LdprmHttpDelete"/>
+      <class name="org.fcrepo.spec.testsuite.versioning.LdprmHttpOptions"/>
+      <class name="org.fcrepo.spec.testsuite.versioning.LdpcvHttpGet"/>
+      <class name="org.fcrepo.spec.testsuite.versioning.LdpcvHttpPost"/>
+      <class name="org.fcrepo.spec.testsuite.versioning.LdpcvHttpDelete"/>
       <class name="org.fcrepo.spec.testsuite.versioning.LdpcvHttpOptions"/>
+
     </classes>
 
   </test>


### PR DESCRIPTION
All @Test annotations are commented out to prevent them from showing up in the results. 
Test implementors simply need to uncomment the annotations in order to add the test to the suite.