### PR TITLE
Fixes broken test: 4.1.1-A-2: The Accept-Datetime header is used to r…

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.spec.testsuite;
 
+import static io.restassured.config.RedirectConfig.redirectConfig;
 import static org.fcrepo.spec.testsuite.Constants.APPLICATION_SPARQL_UPDATE;
 import static org.fcrepo.spec.testsuite.Constants.BASIC_CONTAINER_BODY;
 import static org.fcrepo.spec.testsuite.Constants.BASIC_CONTAINER_LINK_HEADER;
@@ -225,7 +226,7 @@ public class AbstractTest {
 
 
     private RequestSpecification createRequest() {
-        return createRequestAuthOnly().config(RestAssured.config()
+        return createRequestAuthOnly().config(RestAssured.config().redirect(redirectConfig().followRedirects(false))
                                       .logConfig(new LogConfig().defaultStream(ps)
                                                                 .enableLoggingOfRequestAndResponseIfValidationFails()))
                                       .log().all();

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprvHttpGet.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprvHttpGet.java
@@ -114,7 +114,8 @@ public class LdprvHttpGet extends AbstractVersioningTest {
 
         final String rfc1123Date = convertToRfc1123DateTimeString(isoDateString);
 
-        final Response timeGateResponse = doGet(timeGateUri.toString(), new Header("Accept-Datetime", rfc1123Date));
+        final Response timeGateResponse = doGetUnverified(timeGateUri.toString(),
+                                                          new Header("Accept-Datetime", rfc1123Date));
 
         timeGateResponse.then().statusCode(302);
 


### PR DESCRIPTION
…equest a past state, exactly as per [RFC7089] section 2.1.1. A successful response must be a 302 (Found) redirect to the appropriate LDPRm.